### PR TITLE
Update to 0.6.5-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 
 project.ext {
-    SPINE_VERSION = '0.6.2-SNAPSHOT'
+    SPINE_VERSION = '0.6.5-SNAPSHOT'
 
     publishPlugin = "$rootDir/scripts/publish.gradle"
     credentialsPropertyFile = 'credentials.properties'
@@ -42,7 +42,7 @@ subprojects {
         compile group: 'org.spine3', name: 'testutil', version: project.SPINE_VERSION, changing: true
 
         // Guava
-        compile group: 'com.google.guava', name: 'guava', version: '19.0'
+        compile group: 'com.google.guava', name: 'guava', version: '20.0'
 
         // Findbugs
         compile group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.1'

--- a/rdbms/src/main/java/org/spine3/server/storage/jdbc/aggregate/JdbcAggregateStorage.java
+++ b/rdbms/src/main/java/org/spine3/server/storage/jdbc/aggregate/JdbcAggregateStorage.java
@@ -34,9 +34,9 @@ import java.util.Collection;
 import java.util.Iterator;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Throwables.propagate;
 import static com.google.common.collect.Lists.newLinkedList;
 import static org.spine3.io.IoUtil.closeAll;
+import static org.spine3.util.Exceptions.wrapped;
 
 /**
  * The implementation of the aggregate storage based on the RDBMS.
@@ -141,7 +141,7 @@ public class JdbcAggregateStorage<I> extends AggregateStorage<I> {
         try {
             super.close();
         } catch (Exception e) {
-            throw propagate(e);
+            throw wrapped(e);
         }
         closeAll(iterators);
         iterators.clear();

--- a/rdbms/src/main/java/org/spine3/server/storage/jdbc/command/JdbcCommandStorage.java
+++ b/rdbms/src/main/java/org/spine3/server/storage/jdbc/command/JdbcCommandStorage.java
@@ -37,7 +37,7 @@ import org.spine3.validate.Validate;
 import java.util.Iterator;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Throwables.propagate;
+import static org.spine3.util.Exceptions.wrapped;
 import static org.spine3.validate.Validate.checkNotDefault;
 
 /**
@@ -185,7 +185,7 @@ public class JdbcCommandStorage extends CommandStorage {
         try {
             super.close();
         } catch (Exception e) {
-            throw propagate(e);
+            throw wrapped(e);
         }
         dataSource.close();
     }

--- a/rdbms/src/main/java/org/spine3/server/storage/jdbc/entity/JdbcRecordStorage.java
+++ b/rdbms/src/main/java/org/spine3/server/storage/jdbc/entity/JdbcRecordStorage.java
@@ -40,7 +40,7 @@ import java.sql.SQLException;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Throwables.propagate;
+import static org.spine3.util.Exceptions.wrapped;
 
 /**
  * The implementation of the entity storage based on the RDBMS.
@@ -159,7 +159,7 @@ public class JdbcRecordStorage<I> extends RecordStorage<I> {
         try {
             super.close();
         } catch (Exception e) {
-            throw propagate(e);
+            throw wrapped(e);
         }
         dataSource.close();
     }

--- a/rdbms/src/main/java/org/spine3/server/storage/jdbc/event/JdbcEventStorage.java
+++ b/rdbms/src/main/java/org/spine3/server/storage/jdbc/event/JdbcEventStorage.java
@@ -37,9 +37,9 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Iterator;
 
-import static com.google.common.base.Throwables.propagate;
 import static com.google.common.collect.Lists.newLinkedList;
 import static org.spine3.io.IoUtil.closeAll;
+import static org.spine3.util.Exceptions.wrapped;
 
 /**
  * The implementation of the event storage based on the RDBMS.
@@ -137,7 +137,7 @@ public class JdbcEventStorage extends EventStorage {
         try {
             super.close();
         } catch (Exception e) {
-            throw propagate(e);
+            throw wrapped(e);
         }
         closeAll(iterators);
         iterators.clear();

--- a/rdbms/src/main/java/org/spine3/server/storage/jdbc/event/JdbcEventStorage.java
+++ b/rdbms/src/main/java/org/spine3/server/storage/jdbc/event/JdbcEventStorage.java
@@ -59,8 +59,8 @@ import static org.spine3.util.Exceptions.wrapped;
 /**
  * The implementation of the event storage based on the RDBMS.
  *
- * @see JdbcStorageFactory
  * @author Alexander Litus
+ * @see JdbcStorageFactory
  */
 public class JdbcEventStorage extends EventStorage {
 
@@ -68,16 +68,18 @@ public class JdbcEventStorage extends EventStorage {
 
     private final EventStorageQueryFactory queryFactory;
 
-    /** Iterators which are not closed yet. */
+    /**
+     * Iterators which are not closed yet.
+     */
     private final Collection<DbIterator> iterators = newLinkedList();
 
     /**
      * Creates a new storage instance.
      *
-     * @param dataSource            the dataSource wrapper
-     * @param multitenant           defines is this storage multitenant
-     * @param queryFactory          factory that will generate queries for interaction with event table
-     * @throws DatabaseException    if an error occurs during an interaction with the DB
+     * @param dataSource   the dataSource wrapper
+     * @param multitenant  defines is this storage multitenant
+     * @param queryFactory factory that will generate queries for interaction with event table
+     * @throws DatabaseException if an error occurs during an interaction with the DB
      */
     public static JdbcEventStorage newInstance(DataSourceWrapper dataSource,
                                                boolean multitenant,
@@ -133,9 +135,9 @@ public class JdbcEventStorage extends EventStorage {
     @Override
     protected void writeRecord(EventStorageRecord record) throws DatabaseException {
         if (containsRecord(record.getEventId())) {
-           queryFactory.newUpdateEventQuery(record).execute();
+            queryFactory.newUpdateEventQuery(record).execute();
         } else {
-           queryFactory.newInsertEventQuery(record).execute();
+            queryFactory.newInsertEventQuery(record).execute();
         }
     }
 
@@ -208,7 +210,6 @@ public class JdbcEventStorage extends EventStorage {
         }
     }
 
-
     /**
      * Predicate matching an {@link Event} to a single {@link EventFilter}.
      */
@@ -235,8 +236,7 @@ public class JdbcEventStorage extends EventStorage {
         }
 
         private boolean checkFilterEmpty() {
-            return eventFieldFilters.isEmpty()
-                    && contextFieldFilters.isEmpty();
+            return eventFieldFilters.isEmpty() && contextFieldFilters.isEmpty();
         }
 
         // Defined as nullable, parameter `event` is actually non null.
@@ -271,7 +271,6 @@ public class JdbcEventStorage extends EventStorage {
             }
 
             return true;
-
         }
 
         private static boolean checkFields(

--- a/rdbms/src/main/java/org/spine3/server/storage/jdbc/event/JdbcEventStorage.java
+++ b/rdbms/src/main/java/org/spine3/server/storage/jdbc/event/JdbcEventStorage.java
@@ -20,10 +20,22 @@
 
 package org.spine3.server.storage.jdbc.event;
 
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.base.Strings;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.UnmodifiableIterator;
+import com.google.protobuf.Any;
+import com.google.protobuf.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spine3.base.Event;
+import org.spine3.base.EventContext;
 import org.spine3.base.EventId;
+import org.spine3.base.FieldFilter;
+import org.spine3.protobuf.AnyPacker;
+import org.spine3.server.event.EventFilter;
 import org.spine3.server.event.EventStreamQuery;
 import org.spine3.server.storage.EventStorage;
 import org.spine3.server.storage.EventStorageRecord;
@@ -34,9 +46,12 @@ import org.spine3.server.storage.jdbc.util.DataSourceWrapper;
 import org.spine3.server.storage.jdbc.util.DbIterator;
 
 import javax.annotation.Nullable;
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Lists.newLinkedList;
 import static org.spine3.io.IoUtil.closeAll;
 import static org.spine3.util.Exceptions.wrapped;
@@ -95,7 +110,18 @@ public class JdbcEventStorage extends EventStorage {
         final Iterator<EventStorageRecord> iterator = queryFactory.newFilterAndSortQuery(query).execute();
 
         iterators.add((DbIterator) iterator);
-        final Iterator<Event> result = toEventIterator(iterator);
+
+        /**
+         * As each {@code event} data is stored as a single serialized {@code Message}, it is not possible to query
+         * the JDBC storage for {@code Event} or {@code EventContext} field values directly.
+         *
+         * <p>Therefore, we perform in-memory post-filtering according to {@code Event} field and context filters.
+         */
+
+        final List<EventFilter> filterList = query.getFilterList();
+        final UnmodifiableIterator<EventStorageRecord> filtered =
+                Iterators.filter(iterator, new EventRecordPredicate(filterList));
+        final Iterator<Event> result = toEventIterator(filtered);
         return result;
     }
 
@@ -142,6 +168,138 @@ public class JdbcEventStorage extends EventStorage {
         closeAll(iterators);
         iterators.clear();
         dataSource.close();
+    }
+
+    /**
+     * Predicate matching an {@link EventStorageRecord} to a number of {@link EventFilter} instances.
+     */
+    private static class EventRecordPredicate implements Predicate<EventStorageRecord> {
+
+        private final Collection<EventFilter> eventFilters;
+
+        private EventRecordPredicate(Collection<EventFilter> eventFilters) {
+            this.eventFilters = eventFilters;
+        }
+
+        @Override
+        public boolean apply(@Nullable EventStorageRecord eventRecord) {
+            if (eventRecord == null) {
+                return false;
+            }
+
+            if (eventFilters.isEmpty()) {
+                return true;
+            }
+
+            boolean nonEmptyFilterPresent = false;
+            for (EventFilter filter : eventFilters) {
+                final EventFilterChecker predicate = new EventFilterChecker(filter);
+                if (predicate.checkFilterEmpty()) {
+                    continue;
+                }
+                nonEmptyFilterPresent = true;
+                final boolean matches = predicate.apply(eventRecord);
+                if (matches) {
+                    return true;
+                }
+            }
+
+            return !nonEmptyFilterPresent;
+        }
+    }
+
+
+    /**
+     * Predicate matching an {@link Event} to a single {@link EventFilter}.
+     */
+    private static class EventFilterChecker implements Predicate<EventStorageRecord> {
+
+        private final Collection<FieldFilter> eventFieldFilters;
+        private final Collection<FieldFilter> contextFieldFilters;
+
+        private static final Function<Any, Message> ANY_UNPACKER = new Function<Any, Message>() {
+            @Nullable
+            @Override
+            public Message apply(@Nullable Any input) {
+                if (input == null) {
+                    return null;
+                }
+
+                return AnyPacker.unpack(input);
+            }
+        };
+
+        private EventFilterChecker(EventFilter eventFilter) {
+            this.eventFieldFilters = eventFilter.getEventFieldFilterList();
+            this.contextFieldFilters = eventFilter.getContextFieldFilterList();
+        }
+
+        private boolean checkFilterEmpty() {
+            return eventFieldFilters.isEmpty()
+                    && contextFieldFilters.isEmpty();
+        }
+
+        // Defined as nullable, parameter `event` is actually non null.
+        @SuppressWarnings({"MethodWithMoreThanThreeNegations", "MethodWithMultipleLoops"})
+        @Override
+        public boolean apply(@Nullable EventStorageRecord event) {
+            if (event == null) {
+                return false;
+            }
+
+            if (!eventFieldFilters.isEmpty()) {
+                final Any eventWrapped = event.getMessage();
+                final Message eventMessage = AnyPacker.unpack(eventWrapped);
+
+
+                // Check event fields
+                for (FieldFilter filter : eventFieldFilters) {
+                    final boolean matchesFilter = checkFields(eventMessage, filter);
+                    if (!matchesFilter) {
+                        return false;
+                    }
+                }
+            }
+
+            // Check context fields
+            final EventContext context = event.getContext();
+            for (FieldFilter filter : contextFieldFilters) {
+                final boolean matchesFilter = checkFields(context, filter);
+                if (!matchesFilter) {
+                    return false;
+                }
+            }
+
+            return true;
+
+        }
+
+        private static boolean checkFields(
+                Message object,
+                @SuppressWarnings("TypeMayBeWeakened") /*BuilderOrType interface*/ FieldFilter filter) {
+            final String fieldPath = filter.getFieldPath();
+            final String fieldName = fieldPath.substring(fieldPath.lastIndexOf('.') + 1);
+            checkArgument(!Strings.isNullOrEmpty(fieldName), "Field filter " + filter.toString() + " is invalid");
+            final String fieldGetterName = "get" + fieldName.substring(0, 1)
+                    .toUpperCase() + fieldName.substring(1);
+
+            final Collection<Any> expectedAnys = filter.getValueList();
+            final Collection<Message> expectedValues = Collections2.transform(expectedAnys, ANY_UNPACKER);
+            Message actualValue;
+            try {
+                final Class<?> messageClass = object.getClass();
+                final Method fieldGetter = messageClass.getDeclaredMethod(fieldGetterName);
+                actualValue = (Message) fieldGetter.invoke(object);
+                if (actualValue instanceof Any) {
+                    actualValue = AnyPacker.unpack((Any) actualValue);
+                }
+            } catch (@SuppressWarnings("OverlyBroadCatchBlock") ReflectiveOperationException e) {
+                throw wrapped(e);
+            }
+
+            final boolean result = expectedValues.contains(actualValue);
+            return result;
+        }
     }
 
     private enum LogSingleton {

--- a/rdbms/src/main/java/org/spine3/server/storage/jdbc/projection/JdbcProjectionStorage.java
+++ b/rdbms/src/main/java/org/spine3/server/storage/jdbc/projection/JdbcProjectionStorage.java
@@ -36,7 +36,7 @@ import org.spine3.server.storage.jdbc.util.DataSourceWrapper;
 import javax.annotation.Nullable;
 import java.util.Map;
 
-import static com.google.common.base.Throwables.propagate;
+import static org.spine3.util.Exceptions.wrapped;
 
 /**
  * The implementation of the projection storage based on the RDBMS.
@@ -113,7 +113,7 @@ public class JdbcProjectionStorage<I> extends ProjectionStorage<I> {
         try {
             super.close();
         } catch (Exception e) {
-            throw propagate(e);
+            throw wrapped(e);
         }
         // close only entityStorage because it must close dataSource by itself
         entityStorage.close();


### PR DESCRIPTION
Summary of changes:

* Migrate to `core-java: 0.6.5-SNAPSHOT` and bump `jdbc-storage` to `0.6.5-SNAPSHOT` as well.
* Migrate to Guava 20.0 (as `core-java` migrated to Guava 20.0 as well).
* Update unit tests according to the new `Event` filtering features of `core-java`.