### PR TITLE
Add `credentials.properties` decryption to `travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 script:
   - ./gradlew build --debug
 
-  openssl aes-256-cbc -K $encrypted_2b51ae3bcf84_key -iv $encrypted_2b51ae3bcf84_iv -in credentials.properties.enc -out credentials.properties -d
+  - openssl aes-256-cbc -K $encrypted_2b51ae3bcf84_key -iv $encrypted_2b51ae3bcf84_iv -in credentials.properties.enc -out credentials.properties -d
 
   # The publishing script should be executed in `script` section in order to
   # fail the Travis build if execution of this script is failed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ before_install:
 script:
   - ./gradlew build --debug
 
+  openssl aes-256-cbc -K $encrypted_2b51ae3bcf84_key -iv $encrypted_2b51ae3bcf84_iv -in credentials.properties.enc -out credentials.properties -d
+
   # The publishing script should be executed in `script` section in order to
   # fail the Travis build if execution of this script is failed.
   - chmod +x ./scripts/publish-artifacts.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
 script:
   - ./gradlew build --debug
 
+  # Decrypt Maven credentials for artifacts publishing.
   - openssl aes-256-cbc -K $encrypted_2b51ae3bcf84_key -iv $encrypted_2b51ae3bcf84_iv -in credentials.properties.enc -out credentials.properties -d
 
   # The publishing script should be executed in `script` section in order to


### PR DESCRIPTION
This PR fixes artifacts publishing by adding the credentials decryption to `travis.yml`.