### PR TITLE
Migrate to latest `core` and `base`

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -18,10 +18,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-final def SPINE_VERSION = '0.10.46-SNAPSHOT'
+final def SPINE_VERSION = '0.10.67-SNAPSHOT'
 
 ext {
     versionToPublish = SPINE_VERSION
-    spineBaseVersion = '0.10.46-SNAPSHOT'
-    spineCoreVersion = '0.10.46-SNAPSHOT'
+    spineBaseVersion = '0.10.56-SNAPSHOT'
+    spineCoreVersion = '0.10.67-SNAPSHOT'
 }

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorage.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorage.java
@@ -20,7 +20,6 @@
 
 package io.spine.server.storage.jdbc.aggregate;
 
-import com.google.common.base.Optional;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.AggregateEventRecord;
 import io.spine.server.aggregate.AggregateReadRequest;
@@ -34,6 +33,7 @@ import io.spine.server.storage.jdbc.query.DbIterator;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Lists.newLinkedList;
@@ -107,7 +107,7 @@ public class JdbcAggregateStorage<I> extends AggregateStorage<I> {
 
     @Override
     public Optional<LifecycleFlags> readLifecycleFlags(I id) {
-        return Optional.fromNullable(lifecycleFlagsTable.read(id));
+        return Optional.ofNullable(lifecycleFlagsTable.read(id));
     }
 
     @Override

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/UpdateLifecycleFlagsQuery.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/UpdateLifecycleFlagsQuery.java
@@ -57,7 +57,8 @@ class UpdateLifecycleFlagsQuery<I> extends IdAwareQuery<I> implements WriteQuery
         return new Builder<>();
     }
 
-    static class Builder<I> extends IdAwareQuery.Builder<I, Builder<I>, UpdateLifecycleFlagsQuery<I>> {
+    static class Builder<I>
+            extends IdAwareQuery.Builder<I, Builder<I>, UpdateLifecycleFlagsQuery<I>> {
 
         private LifecycleFlags entityStatus;
 

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/query/AbstractQuery.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/query/AbstractQuery.java
@@ -127,17 +127,14 @@ public abstract class AbstractQuery implements StorageQuery {
      */
     @VisibleForTesting
     static AbstractSQLQueryFactory<?> createFactory(final DataSourceWrapper dataSource) {
-        Provider<Connection> connectionProvider = new Provider<Connection>() {
-            @Override
-            public Connection get() {
-                Connection connection = dataSource.getConnection(false)
-                                                  .get();
-                try {
-                    connection.setHoldability(HOLD_CURSORS_OVER_COMMIT);
-                    return connection;
-                } catch (SQLException e) {
-                    throw new DatabaseException(e);
-                }
+        Provider<Connection> connectionProvider = () -> {
+            Connection connection = dataSource.getConnection(false)
+                                              .get();
+            try {
+                connection.setHoldability(HOLD_CURSORS_OVER_COMMIT);
+                return connection;
+            } catch (SQLException e) {
+                throw new DatabaseException(e);
             }
         };
         SQLTemplates templates = getDialectTemplates(dataSource);

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/query/AbstractTable.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/query/AbstractTable.java
@@ -85,9 +85,9 @@ public abstract class AbstractTable<I, R, W> {
      * the default values of the Columns as the map values.
      */
     private static final ImmutableMap<String, Object> COLUMN_DEFAULTS =
-            ImmutableMap.<String, Object>of(archived.name(), false,
-                                            deleted.name(), false,
-                                            version.name(), 0);
+            ImmutableMap.of(archived.name(), false,
+                            deleted.name(), false,
+                            version.name(), 0);
     private final String name;
     private final IdColumn<I> idColumn;
     private final DataSourceWrapper dataSource;

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/query/IdColumn.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/query/IdColumn.java
@@ -24,7 +24,6 @@ import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.entity.Entity;
-import io.spine.server.entity.EntityClass;
 import io.spine.server.storage.jdbc.Type;
 
 import java.util.Collection;
@@ -32,6 +31,7 @@ import java.util.Collection;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Lists.newLinkedList;
 import static io.spine.json.Json.toCompactJson;
+import static io.spine.server.entity.model.EntityClass.asEntityClass;
 
 /**
  * A helper class for setting the {@link Entity} ID into {@linkplain Parameters query parameters}.
@@ -59,7 +59,7 @@ public abstract class IdColumn<I> {
     static <I> IdColumn<I> newInstance(Class<? extends Entity<I, ?>> entityClass,
                                        String columnName) {
         IdColumn<I> helper;
-        Class<?> idClass = new EntityClass<Entity>(entityClass).getIdClass();
+        Class<?> idClass = asEntityClass(entityClass).getIdClass();
         if (idClass == Long.class) {
             helper = (IdColumn<I>) new LongIdColumn(columnName);
         } else if (idClass == Integer.class) {

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/record/JdbcRecordStorage.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/record/JdbcRecordStorage.java
@@ -22,7 +22,6 @@ package io.spine.server.storage.jdbc.record;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import com.google.protobuf.Any;
 import com.google.protobuf.FieldMask;
 import io.spine.base.Identifier;
@@ -49,6 +48,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.transform;
@@ -102,7 +102,7 @@ public class JdbcRecordStorage<I> extends RecordStorage<I> {
     @Override
     protected Optional<EntityRecord> readRecord(I id) throws DatabaseException {
         EntityRecord record = table.read(id);
-        return Optional.fromNullable(record);
+        return Optional.ofNullable(record);
     }
 
     @Override

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/record/JdbcRecordStorage.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/record/JdbcRecordStorage.java
@@ -21,7 +21,6 @@
 package io.spine.server.storage.jdbc.record;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
 import com.google.protobuf.Any;
 import com.google.protobuf.FieldMask;
 import io.spine.base.Identifier;
@@ -49,9 +48,11 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.Iterables.transform;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
 
 /**
  * The implementation of the entity storage based on the RDBMS.
@@ -172,7 +173,9 @@ public class JdbcRecordStorage<I> extends RecordStorage<I> {
     }
 
     private EntityQuery<I> toQuery(Iterable<? extends I> ids) {
-        Iterable<EntityId> entityIds = transform(ids, AggregateStateIdToEntityId.INSTANCE);
+        Iterable<EntityId> entityIds = stream(ids.spliterator(), false)
+                .map(AggregateStateIdToEntityId.INSTANCE)
+                .collect(toList());
         EntityIdFilter idFilter = EntityIdFilter.newBuilder()
                                                 .addAllIds(entityIds)
                                                 .build();

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/record/RecordTable.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/record/RecordTable.java
@@ -20,7 +20,6 @@
 
 package io.spine.server.storage.jdbc.record;
 
-import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import com.google.protobuf.FieldMask;
 import io.spine.server.entity.Entity;
@@ -44,9 +43,10 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.Collections2.transform;
 import static com.google.common.collect.Lists.newLinkedList;
 import static io.spine.server.storage.jdbc.Type.BYTE_ARRAY;
 import static java.util.Collections.addAll;
@@ -83,7 +83,9 @@ class RecordTable<I> extends EntityTable<I, EntityRecord, EntityRecordWithColumn
     protected List<TableColumn> getTableColumns() {
         List<TableColumn> columns = newLinkedList();
         addAll(columns, StandardColumn.values());
-        Collection<TableColumn> tableColumns = transform(entityColumns, new ColumnAdapter());
+        Collection<TableColumn> tableColumns = entityColumns.stream()
+                                                            .map(new ColumnAdapter())
+                                                            .collect(Collectors.toList());
         columns.addAll(tableColumns);
         return columns;
     }

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/record/WriteEntityQuery.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/record/WriteEntityQuery.java
@@ -127,7 +127,7 @@ abstract class WriteEntityQuery<I, C extends StoreClause<C>> extends AbstractQue
             ColumnRecords.feedColumnsTo(parameters,
                                         record,
                                         columnTypeRegistry,
-                                        Functions.<String>identity());
+                                        Functions.identity());
         }
         return parameters.build();
     }

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/stand/JdbcStandStorage.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/stand/JdbcStandStorage.java
@@ -22,7 +22,6 @@ package io.spine.server.storage.jdbc.stand;
 
 import com.google.common.base.Converter;
 import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterators;
 import com.google.protobuf.Any;
@@ -49,6 +48,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -164,7 +164,7 @@ public class JdbcStandStorage extends StandStorage {
         List<EntityRecord> readList = newArrayList(read);
         checkState(readList.size() <= 1);
         if (readList.isEmpty()) {
-            return Optional.absent();
+            return Optional.empty();
         } else {
             return Optional.of(readList.get(0));
         }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/DefaultDataSourceConfigConverterTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/DefaultDataSourceConfigConverterTest.java
@@ -24,9 +24,9 @@ import com.google.common.testing.NullPointerTester;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.test.DisplayNames.HAVE_PARAMETERLESS_CTOR;
-import static io.spine.test.DisplayNames.NOT_ACCEPT_NULLS;
-import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
+import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
+import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
+import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.mockito.Mockito.mock;
 
 /**

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/PredefinedMappingTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/PredefinedMappingTest.java
@@ -30,7 +30,7 @@ import java.sql.SQLException;
 import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
 import static io.spine.server.storage.jdbc.PredefinedMapping.POSTGRESQL_10_1;
 import static io.spine.server.storage.jdbc.PredefinedMapping.select;
-import static io.spine.test.Tests.nullRef;
+import static io.spine.testing.Tests.nullRef;
 import static io.spine.util.Exceptions.illegalStateWithCauseOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/SqlTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/SqlTest.java
@@ -23,8 +23,8 @@ package io.spine.server.storage.jdbc;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.test.DisplayNames.HAVE_PARAMETERLESS_CTOR;
-import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
+import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
+import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/CloseablesTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/CloseablesTest.java
@@ -32,9 +32,9 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import static io.spine.test.DisplayNames.HAVE_PARAMETERLESS_CTOR;
-import static io.spine.test.DisplayNames.NOT_ACCEPT_NULLS;
-import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
+import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
+import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
+import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static java.util.Collections.singleton;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorageTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorageTest.java
@@ -37,7 +37,7 @@ import java.sql.SQLException;
 
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
 import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
-import static io.spine.test.Tests.nullRef;
+import static io.spine.testing.Tests.nullRef;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorageVisibilityHandlingTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorageVisibilityHandlingTest.java
@@ -20,7 +20,6 @@
 
 package io.spine.server.storage.jdbc.aggregate;
 
-import com.google.common.base.Optional;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.AggregateStorage;
 import io.spine.server.aggregate.AggregateStorageVisibilityHandlingTest;
@@ -32,6 +31,8 @@ import io.spine.test.aggregate.ProjectId;
 import io.spine.testdata.Sample;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
 
 import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/MultipleExceptionsOnCloseTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/MultipleExceptionsOnCloseTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static io.spine.test.Verify.assertContains;
+import static io.spine.testing.Verify.assertContains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/projection/JdbcProjectionStorageTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/projection/JdbcProjectionStorageTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
-import static io.spine.test.Tests.nullRef;
+import static io.spine.testing.Tests.nullRef;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/projection/given/JdbcProjectionStorageTestEnv.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/projection/given/JdbcProjectionStorageTestEnv.java
@@ -33,7 +33,7 @@ public class JdbcProjectionStorageTestEnv {
     private JdbcProjectionStorageTestEnv() {
     }
 
-    public static class TestEntity extends RecordStorageTestEnv.TestCounterEntity<ProjectId> {
+    public static class TestEntity extends RecordStorageTestEnv.TestCounterEntity {
         protected TestEntity(ProjectId id) {
             super(id);
         }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/DbTableNameFactoryTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/DbTableNameFactoryTest.java
@@ -26,9 +26,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static io.spine.server.storage.jdbc.query.DbTableNameFactory.newTableName;
-import static io.spine.test.DisplayNames.HAVE_PARAMETERLESS_CTOR;
-import static io.spine.test.DisplayNames.NOT_ACCEPT_NULLS;
-import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
+import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
+import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
+import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/QueryPredicatesTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/QueryPredicatesTest.java
@@ -50,8 +50,8 @@ import static io.spine.server.storage.jdbc.query.QueryPredicates.columnMatchFilt
 import static io.spine.server.storage.jdbc.query.QueryPredicates.joinPredicates;
 import static io.spine.server.storage.jdbc.query.QueryPredicates.nullFilter;
 import static io.spine.server.storage.jdbc.query.QueryPredicates.valueFilter;
-import static io.spine.test.DisplayNames.HAVE_PARAMETERLESS_CTOR;
-import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
+import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
+import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/SerializerTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/SerializerTest.java
@@ -27,8 +27,8 @@ import org.junit.jupiter.api.Test;
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.server.storage.jdbc.query.Serializer.deserialize;
 import static io.spine.server.storage.jdbc.query.Serializer.serialize;
-import static io.spine.test.DisplayNames.HAVE_PARAMETERLESS_CTOR;
-import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
+import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
+import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/record/QueryResultsTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/record/QueryResultsTest.java
@@ -23,8 +23,8 @@ package io.spine.server.storage.jdbc.record;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.test.DisplayNames.HAVE_PARAMETERLESS_CTOR;
-import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
+import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
+import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Dmytro Dashenkov

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/record/given/JdbcRecordStorageTestEnv.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/record/given/JdbcRecordStorageTestEnv.java
@@ -24,6 +24,7 @@ import io.spine.server.entity.AbstractEntity;
 import io.spine.server.entity.storage.Column;
 import io.spine.server.storage.given.RecordStorageTestEnv.TestCounterEntity;
 import io.spine.test.storage.Project;
+import io.spine.test.storage.ProjectId;
 
 /**
  * @author Dmytro Grankin
@@ -36,8 +37,8 @@ public class JdbcRecordStorageTestEnv {
     private JdbcRecordStorageTestEnv() {
     }
 
-    public static class TestCounterEntityJdbc extends TestCounterEntity<String> {
-        protected TestCounterEntityJdbc(String id) {
+    public static class TestCounterEntityJdbc extends TestCounterEntity {
+        protected TestCounterEntityJdbc(ProjectId id) {
             super(id);
         }
     }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/stand/JdbcStandStorageTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/stand/JdbcStandStorageTest.java
@@ -20,7 +20,6 @@
 
 package io.spine.server.storage.jdbc.stand;
 
-import com.google.common.base.Optional;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.FieldMask;
@@ -52,6 +51,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
@@ -59,8 +59,8 @@ import static io.spine.server.storage.jdbc.stand.given.Given.TestAggregate;
 import static io.spine.server.storage.jdbc.stand.given.Given.TestAggregate2;
 import static io.spine.server.storage.jdbc.stand.given.Given.testAggregates;
 import static io.spine.server.storage.jdbc.stand.given.Given.testAggregatesWithState;
-import static io.spine.test.Verify.assertContains;
-import static io.spine.test.Verify.assertSize;
+import static io.spine.testing.Verify.assertContains;
+import static io.spine.testing.Verify.assertSize;
 import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/type/JdbcColumnTypeTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/type/JdbcColumnTypeTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.sql.SQLException;
 
 import static io.spine.base.Identifier.newUuid;
-import static io.spine.test.Tests.nullRef;
+import static io.spine.testing.Tests.nullRef;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/type/JdbcColumnTypesTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/type/JdbcColumnTypesTest.java
@@ -23,8 +23,8 @@ package io.spine.server.storage.jdbc.type;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.test.DisplayNames.HAVE_PARAMETERLESS_CTOR;
-import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
+import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
+import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Dmytro Dashenkov

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/type/JdbcTypeRegistryFactoryTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/type/JdbcTypeRegistryFactoryTest.java
@@ -27,8 +27,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static io.spine.server.storage.jdbc.type.given.JdbcTypeRegistryFactoryTestEnv.columnWithType;
-import static io.spine.test.DisplayNames.HAVE_PARAMETERLESS_CTOR;
-import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
+import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
+import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 


### PR DESCRIPTION
This PR migrates `jdbc-storage` repository to the latest available versions of `core` and `base`.

Also, the Guava Functional API was replaced by the JDK 8 counterparts where possible and lambdas were used instead of anonymous classes where possible.

Spine version advances to `0.10.67-SNAPSHOT`.