### PR TITLE
Enable PMD static analysis and ErrorProne compiler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,12 +18,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-buildscript {
+buildscript {final scriptHandler ->
     // Define the versions of the library and its dependencies.
     // As long as `buildscript` section is always evaluated first, we need to apply
     // `version.gradle` explicitly here.
     apply from: "$rootDir/config/gradle/dependencies.gradle"
     apply from: "$rootDir/version.gradle"
+
+
+    defaultRepositories(scriptHandler)
+    dependencies {
+        classpath deps.build.gradlePlugins.errorProne
+    }
+
+    forceConfiguration(scriptHandler)
+
 }
 
 ext {
@@ -41,25 +50,14 @@ allprojects {
 
 subprojects {
     apply plugin: 'java-library'
+    apply plugin: 'net.ltgt.errorprone'
+    apply plugin: 'pmd'
     apply plugin: 'maven-publish'
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
 
-    // Set Java home to point to JDK8 in gradle.properties file.
-    //
-    // For Mac OS X, it looks like this:
-    //
-    // # suppress inspection "UnusedProperty"
-    // org.gradle.java.home=/Library/Java/JavaVirtualMachines/jdk1.8.0_51.jdk/Contents/Home/
-
-    repositories {
-        mavenLocal()
-        jcenter()
-
-        maven { url = repos.spine }
-        maven { url = repos.spineSnapshots }
-    }
+    defaultRepositories(project)
 
     dependencies {
 
@@ -78,9 +76,10 @@ subprojects {
         testImplementation group: 'io.spine', name: 'spine-server', version: spineCoreVersion,
                 classifier: 'test', excludes
 
-
         testImplementation group: 'io.spine', name: 'spine-testlib', version: spineBaseVersion
 
+        errorprone deps.build.errorProneCore
+        errorproneJavac deps.build.errorProneJavac
         implementation deps.build.guava
         implementation deps.build.jsr305Annotations
         implementation deps.build.checkerAnnotations
@@ -123,6 +122,8 @@ subprojects {
     }
     
     check.dependsOn jacocoTestReport
+
+    apply from: deps.scripts.pmd
 }
 
 apply from: deps.scripts.jacoco

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/DataSourceWrapper.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/DataSourceWrapper.java
@@ -21,8 +21,7 @@
 package io.spine.server.storage.jdbc;
 
 import io.spine.annotation.Internal;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.spine.logging.Logging;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -30,16 +29,13 @@ import java.sql.SQLException;
 
 /**
  * Wrapper for {@link DataSource} instances.
- *
- * @author Alexander Litus
- * @author Andrey Lavrov
  */
 @Internal
-public class DataSourceWrapper implements AutoCloseable {
+public class DataSourceWrapper implements AutoCloseable, Logging {
 
     private final DataSource dataSource;
 
-    /** Wraps custom {@link DataSource} implementation */
+    /** Wraps custom {@link DataSource} implementation. */
     static DataSourceWrapper wrap(DataSource dataSource) {
         return new DataSourceWrapper(dataSource);
     }
@@ -61,7 +57,7 @@ public class DataSourceWrapper implements AutoCloseable {
             ConnectionWrapper wrapper = ConnectionWrapper.wrap(connection);
             return wrapper;
         } catch (SQLException e) {
-            log().error("Failed to get connection.", e);
+            _error("Failed to get connection.", e);
             throw new DatabaseException(e);
         }
     }
@@ -79,21 +75,11 @@ public class DataSourceWrapper implements AutoCloseable {
             try {
                 ((AutoCloseable) dataSource).close();
             } catch (Exception e) {
-                log().error("Error occurred while closing DataSource ", e);
+                _error("Error occurred while closing DataSource ", e);
                 throw new DatabaseException(e);
             }
             return;
         }
-        log().warn("Close method is not implemented in " + dataSource.getClass());
-    }
-
-    private static Logger log() {
-        return LogSingleton.INSTANCE.value;
-    }
-
-    private enum LogSingleton {
-        INSTANCE;
-        @SuppressWarnings("NonSerializableFieldInSerializableClass")
-        private final Logger value = LoggerFactory.getLogger(DataSourceWrapper.class);
+        _warn("Close method is not implemented in " + dataSource.getClass());
     }
 }

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/PredefinedMapping.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/PredefinedMapping.java
@@ -21,6 +21,7 @@
 package io.spine.server.storage.jdbc;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.errorprone.annotations.Immutable;
 import io.spine.type.TypeName;
 
 import java.sql.DatabaseMetaData;
@@ -31,9 +32,8 @@ import static io.spine.server.storage.jdbc.TypeMappingBuilder.basicBuilder;
 
 /**
  * Predefined {@linkplain TypeMapping type mappings} for different databases.
- *
- * @author Dmytro Grankin
  */
+@Immutable
 public enum PredefinedMapping implements TypeMapping {
 
     MYSQL_5_7("MySQL", 5, 7, basicBuilder()),

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/Sql.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/Sql.java
@@ -28,10 +28,8 @@ package io.spine.server.storage.jdbc;
  *
  * <p>All the {@code enum} values have a valid token string representation, i.e.
  * {@link Enum#toString() toString()} method returns a valid SQL token wrapped into the whitespaces.
- *
- * @author Dmytro Dashenkov
  */
-@SuppressWarnings("UtilityClass")
+@SuppressWarnings({"UtilityClass", "PMD.MissingStaticMethodInNonInstantiatableClass"})
 public final class Sql {
 
     private Sql() {

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/TypeMapping.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/TypeMapping.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.storage.jdbc;
 
+import com.google.errorprone.annotations.Immutable;
 import io.spine.type.TypeName;
 
 /**
@@ -33,6 +34,7 @@ import io.spine.type.TypeName;
  *
  * @author Dmytro Grankin
  */
+@Immutable
 public interface TypeMapping {
 
     /**

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/TypeMappingBuilder.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/TypeMappingBuilder.java
@@ -20,6 +20,8 @@
 
 package io.spine.server.storage.jdbc;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.Immutable;
 import io.spine.type.TypeName;
 
 import java.util.EnumMap;
@@ -107,12 +109,13 @@ public class TypeMappingBuilder {
     /**
      * A {@link TypeMapping}, which is created by the {@link TypeMappingBuilder}.
      */
+    @Immutable
     private static final class TypeMappingImpl implements TypeMapping {
 
-        private final Map<Type, TypeName> mappedTypes;
+        private final ImmutableMap<Type, TypeName> mappedTypes;
 
         private TypeMappingImpl(Map<Type, TypeName> mappedTypes) {
-            this.mappedTypes = mappedTypes;
+            this.mappedTypes = ImmutableMap.copyOf(mappedTypes);
         }
 
         @Override

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/AggregateEventRecordTable.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/AggregateEventRecordTable.java
@@ -88,7 +88,11 @@ class AggregateEventRecordTable<I> extends EntityTable<I,
     }
 
     /**
-     * @throws IllegalStateException always, because {@link AggregateEventRecord} is immutable
+     * Always throws an {@link IllegalStateException}, because {@link AggregateEventRecord}
+     * is immutable.
+     *
+     * @throws IllegalStateException
+     *         always
      */
     @Override
     protected WriteQuery composeUpdateQuery(I id, AggregateEventRecord record) {

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/Closeables.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/Closeables.java
@@ -20,15 +20,13 @@
 
 package io.spine.server.storage.jdbc.aggregate;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * A utility class for working with {@link AutoCloseable} instances.
- *
- * @author Dmytro Dashenkov
  */
 class Closeables {
 
@@ -50,7 +48,7 @@ class Closeables {
      */
     static void closeAll(Iterable<? extends AutoCloseable> closeables) {
         checkNotNull(closeables);
-        Collection<Exception> exceptions = new LinkedList<>();
+        Collection<Exception> exceptions = new ArrayList<>();
         for (AutoCloseable closable : closeables) {
             try {
                 closable.close();

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/MultipleExceptionsOnClose.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/MultipleExceptionsOnClose.java
@@ -22,6 +22,7 @@ package io.spine.server.storage.jdbc.aggregate;
 
 import com.google.common.base.Throwables;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 import static java.lang.String.format;
@@ -40,7 +41,7 @@ final class MultipleExceptionsOnClose extends Throwable {
 
     MultipleExceptionsOnClose(Collection<Exception> exceptions) {
         super(format("%s fatal exceptions.", exceptions.size()));
-        this.exceptions = exceptions;
+        this.exceptions = new ArrayList<>(exceptions);
     }
 
     /**
@@ -49,13 +50,10 @@ final class MultipleExceptionsOnClose extends Throwable {
      * @return the description for all the exceptions
      */
     @Override
-    public String toString() {
+    public String getMessage() {
         @SuppressWarnings("StringBufferWithoutInitialCapacity")
         // We don't know the size of the stacktrace.
         StringBuilder builder = new StringBuilder();
-        String selfInfo = super.toString();
-        builder.append(selfInfo)
-               .append(lineSeparator());
         for (Exception exception : exceptions) {
             String stackTrace = Throwables.getStackTraceAsString(exception);
             builder.append(stackTrace)

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/MultipleExceptionsOnClose.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/MultipleExceptionsOnClose.java
@@ -31,8 +31,6 @@ import static java.lang.System.lineSeparator;
 /**
  * An {@link Exception} telling that there were <b>multiple</b> exceptions while trying to
  * {@link Closeables#closeAll(Iterable)} close} multiple closeables.
- *
- * @author Dmytro Dashenkov
  */
 final class MultipleExceptionsOnClose extends Throwable {
 

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/projection/LastHandledEventTimeTable.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/projection/LastHandledEventTimeTable.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.storage.jdbc.projection;
 
+import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Timestamp;
 import io.spine.server.storage.jdbc.DataSourceWrapper;
 import io.spine.server.storage.jdbc.TableColumn;
@@ -31,7 +32,6 @@ import io.spine.server.storage.jdbc.query.WriteQuery;
 
 import java.util.List;
 
-import static com.google.common.collect.ImmutableList.copyOf;
 import static io.spine.server.storage.jdbc.Type.INT;
 import static io.spine.server.storage.jdbc.Type.LONG;
 import static io.spine.server.storage.jdbc.Type.STRING_255;
@@ -59,7 +59,7 @@ class LastHandledEventTimeTable extends AbstractTable<String, Timestamp, Timesta
 
     @Override
     protected List<? extends TableColumn> getTableColumns() {
-        return copyOf(Column.values());
+        return ImmutableList.copyOf(Column.values());
     }
 
     @Override

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/query/AbstractTable.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/query/AbstractTable.java
@@ -24,13 +24,13 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.spine.annotation.Internal;
+import io.spine.logging.Logging;
 import io.spine.server.storage.jdbc.DataSourceWrapper;
 import io.spine.server.storage.jdbc.TableColumn;
 import io.spine.server.storage.jdbc.Type;
 import io.spine.server.storage.jdbc.TypeMapping;
 import io.spine.type.TypeName;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.slf4j.Logger;
 
 import java.util.HashSet;
 import java.util.Iterator;
@@ -50,7 +50,6 @@ import static io.spine.server.storage.jdbc.Sql.Query.DEFAULT;
 import static io.spine.server.storage.jdbc.Sql.Query.NOT;
 import static io.spine.server.storage.jdbc.Sql.Query.NULL;
 import static io.spine.server.storage.jdbc.Sql.Query.PRIMARY_KEY;
-import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * A representation of an SQL table.
@@ -72,7 +71,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @see TableColumn
  */
 @Internal
-public abstract class AbstractTable<I, R, W> {
+public abstract class AbstractTable<I, R, W> implements Logging {
 
     /**
      * A map of the Spine common Entity Columns to their default values.
@@ -354,15 +353,5 @@ public abstract class AbstractTable<I, R, W> {
                                              .setDataSource(dataSource)
                                              .build();
         query.execute();
-    }
-
-    private static Logger log() {
-        return LogSingleton.INSTANCE.value;
-    }
-
-    private enum LogSingleton {
-        INSTANCE;
-        @SuppressWarnings("NonSerializableFieldInSerializableClass")
-        private final Logger value = getLogger(AbstractTable.class);
     }
 }

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/query/MessageBytesColumnReader.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/query/MessageBytesColumnReader.java
@@ -63,7 +63,9 @@ final class MessageBytesColumnReader<M extends Message> extends ColumnReader<M> 
     public M readValue(ResultSet resultSet) throws SQLException {
         checkNotNull(resultSet);
         byte[] bytes = resultSet.getBytes(columnName());
-        M result = deserialize(bytes, messageDescriptor);
+
+        @SuppressWarnings("unchecked") // It's up to user to provide correct binary data for unpack.
+        M result = (M) deserialize(bytes, messageDescriptor);
         return result;
     }
 }

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/query/SelectMessageByIdQuery.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/query/SelectMessageByIdQuery.java
@@ -37,7 +37,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @param <I> a type of storage message IDs
  * @param <M> a type of messages to read
- * @author Dmytro Grankin
  */
 public abstract class SelectMessageByIdQuery<I, M extends Message> extends AbstractSelectByIdQuery<I, M> {
 
@@ -94,7 +93,9 @@ public abstract class SelectMessageByIdQuery<I, M extends Message> extends Abstr
         if (bytes == null) {
             return null;
         }
-        M message = Serializer.deserialize(bytes, messageDescriptor);
+
+        @SuppressWarnings("unchecked") // It's up to user to provide correct binary data for unpack.
+        M message = (M) Serializer.deserialize(bytes, messageDescriptor);
         return message;
     }
 

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/query/Serializer.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/query/Serializer.java
@@ -59,11 +59,9 @@ public final class Serializer {
      *
      * @param bytes             the serialized message
      * @param messageDescriptor the descriptor of a message
-     * @param <M>               the type of message expected
      * @return a message instance
      */
-    @SuppressWarnings("unchecked") // It's up to user to provide correct binary data for unpack.
-    static <M extends Message> M deserialize(byte[] bytes, Descriptor messageDescriptor) {
+    static Message deserialize(byte[] bytes, Descriptor messageDescriptor) {
         checkNotNull(bytes);
         Any.Builder builder = Any.newBuilder();
         String typeUrlValue = TypeUrl.from(messageDescriptor)
@@ -71,7 +69,7 @@ public final class Serializer {
         builder.setTypeUrl(typeUrlValue);
         ByteString byteString = ByteString.copyFrom(bytes);
         builder.setValue(byteString);
-        M message = (M) AnyPacker.unpack(builder.build());
-        return message;
+        Message result = AnyPacker.unpack(builder.build());
+        return result;
     }
 }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/SqlTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/SqlTest.java
@@ -27,9 +27,6 @@ import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
 import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/**
- * @author Dmytro Dashenkov
- */
 @DisplayName("Sql utility should")
 class SqlTest {
 

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/SerializerTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/SerializerTest.java
@@ -32,9 +32,6 @@ import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * @author Alexander Litus
- */
 @DisplayName("Serializer should")
 class SerializerTest {
 
@@ -56,7 +53,7 @@ class SerializerTest {
         byte[] bytes = serialize(expected);
         assertTrue(bytes.length > 0);
 
-        StringValue actual = deserialize(bytes, expected.getDescriptorForType());
+        StringValue actual = (StringValue) deserialize(bytes, expected.getDescriptorForType());
         assertEquals(expected, actual);
     }
 }

--- a/version.gradle
+++ b/version.gradle
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-final def SPINE_VERSION = '1.0.0-pre4'
+final def SPINE_VERSION = '1.0.0-SNAPSHOT'
 
 ext {
     versionToPublish = SPINE_VERSION


### PR DESCRIPTION
As per title, this PR enables the static analysis with PMD rules and includes ErrorProne checks into the compilation process.

The library version is set to `1.0.0-SNAPSHOT`.