### PR TITLE
 Ensure we always use OpenJDK8 to build the project.

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,3 +1,0 @@
----
-exclude_paths:
-  - "**/src/test/**/*.*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 
+jdk:
+  - openjdk8
+
 before_install:
   - chmod +x gradlew
   - pip install --user codecov

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # jdbc-storage
 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/c2dc1b9b00454d4594a3a59de75c41e4)](https://www.codacy.com/app/SpineEventEngine/jdbc-storage?utm_source=github.com&utm_medium=referral&utm_content=SpineEventEngine/jdbc-storage&utm_campaign=badger)
-
 Support of storage in JDBC-compliant databases.
 
 ### Configuration


### PR DESCRIPTION
In the PR I have enforced usage of the OpenJDK8 with our Travis CI builds.

As a part of the PR, I have also removed obsolete `codacy` configuration and badge.