### PR TITLE
Mark the library packages `@Experimental` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Support of storage in JDBC-compliant databases.
 
+At this point, this library is **experimental**, and its API is a subject for future changes.
+
+For the production use, consider NoSQL storage implementations such as Google Cloud Datastore. 
+See [gcloud-java](https://github.com/SpineEventEngine/gcloud-java/) for Google Cloud support.  
+
 ### Configuration
 
 To support working with different JDBC drivers, the library uses [Querydsl](http://www.querydsl.com/)

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/package-info.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/package-info.java
@@ -23,10 +23,12 @@
  * {@link io.spine.server.aggregate.AggregateStorage AggregateStorage}.
  */
 
+@Experimental
 @CheckReturnValue
 @ParametersAreNonnullByDefault
 package io.spine.server.storage.jdbc.aggregate;
 
 import com.google.errorprone.annotations.CheckReturnValue;
+import io.spine.annotation.Experimental;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/package-info.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/package-info.java
@@ -23,10 +23,12 @@
  * of {@code InboxStorage} and other mechanisms of message delivery.
  */
 
+@Experimental
 @CheckReturnValue
 @ParametersAreNonnullByDefault
 package io.spine.server.storage.jdbc.delivery;
 
 import com.google.errorprone.annotations.CheckReturnValue;
+import io.spine.annotation.Experimental;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/message/package-info.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/message/package-info.java
@@ -24,11 +24,13 @@
  */
 
 @Internal
+@Experimental
 @CheckReturnValue
 @ParametersAreNonnullByDefault
 package io.spine.server.storage.jdbc.message;
 
 import com.google.errorprone.annotations.CheckReturnValue;
+import io.spine.annotation.Experimental;
 import io.spine.annotation.Internal;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/package-info.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/package-info.java
@@ -21,12 +21,16 @@
 /**
  * The API for the JDBC-based storage implementation.
  *
+ * <p>This API is experimental and is a subject for changes in future releases.
+ *
  * @see io.spine.server.storage.jdbc.JdbcStorageFactory for the library entry point
  */
+@Experimental
 @CheckReturnValue
 @ParametersAreNonnullByDefault
 package io.spine.server.storage.jdbc;
 
 import com.google.errorprone.annotations.CheckReturnValue;
+import io.spine.annotation.Experimental;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/projection/package-info.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/projection/package-info.java
@@ -23,10 +23,12 @@
  * {@link io.spine.server.projection.ProjectionStorage ProjectionStorage}.
  */
 
+@Experimental
 @CheckReturnValue
 @ParametersAreNonnullByDefault
 package io.spine.server.storage.jdbc.projection;
 
 import com.google.errorprone.annotations.CheckReturnValue;
+import io.spine.annotation.Experimental;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/query/package-info.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/query/package-info.java
@@ -26,11 +26,13 @@
  */
 
 @Internal
+@Experimental
 @CheckReturnValue
 @ParametersAreNonnullByDefault
 package io.spine.server.storage.jdbc.query;
 
 import com.google.errorprone.annotations.CheckReturnValue;
+import io.spine.annotation.Experimental;
 import io.spine.annotation.Internal;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/record/package-info.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/record/package-info.java
@@ -24,8 +24,10 @@
 
 @CheckReturnValue
 @ParametersAreNonnullByDefault
+@Experimental
 package io.spine.server.storage.jdbc.record;
 
 import com.google.errorprone.annotations.CheckReturnValue;
+import io.spine.annotation.Experimental;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/type/package-info.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/type/package-info.java
@@ -20,10 +20,12 @@
 /**
  * This package provides classes for JDBC column types.
  */
+@Experimental
 @CheckReturnValue
 @ParametersAreNonnullByDefault
 package io.spine.server.storage.jdbc.type;
 
 import com.google.errorprone.annotations.CheckReturnValue;
+import io.spine.annotation.Experimental;
 
 import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
This PR marks the support of JDBC-compliant storage engines as experimental.