### PR TITLE
Release 1.1.0

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -1,0 +1,24 @@
+name: Tests on Windows
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+        
+    - name: Pull config
+      run: git submodule update --init --recursive
+
+    - name: Run tests with Gradle
+      run: gradlew.bat build

--- a/.idea/dictionaries/common.xml
+++ b/.idea/dictionaries/common.xml
@@ -7,6 +7,7 @@
       <w>bytebuffer</w>
       <w>closeables</w>
       <w>cqrs</w>
+      <w>dartdocs</w>
       <w>dataset</w>
       <w>datastore</w>
       <w>datastores</w>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Gradle:
 ```groovy
 dependencies {
     implementation (
-        "io.spine:spine-rdbms:1.0.1"
+        "io.spine:spine-rdbms:1.1.0"
     )
 }
 ```

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-rdbms:1.0.3`
+# Dependencies of `io.spine:spine-rdbms:1.1.0`
 
 ## Runtime
 1. **Group:** com.google.auto.value **Name:** auto-value-annotations **Version:** 1.6.3
@@ -77,8 +77,6 @@
 
 1. **Group:** com.h2database **Name:** h2 **Version:** 1.4.196
      * **Manifest license URL:** [http://www.h2database.com/html/license.html](http://www.h2database.com/html/license.html)
-     * **POM Project URL:** [http://www.h2database.com](http://www.h2database.com)
-     * **POM License: MPL 2.0 or EPL 1.0** - [http://h2database.com/html/license.html](http://h2database.com/html/license.html)
 
 1. **Group:** com.infradna.tool **Name:** bridge-method-annotation **Version:** 1.13
      * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
@@ -110,8 +108,6 @@
 
 1. **Group:** joda-time **Name:** joda-time **Version:** 1.6
      * **Manifest License:** Apache 2.0 (Not packaged)
-     * **POM Project URL:** [http://joda-time.sourceforge.net](http://joda-time.sourceforge.net)
-     * **POM License: Apache 2** - [http://www.apache.org/licenses/](http://www.apache.org/licenses/)
 
 1. **Group:** junit **Name:** junit **Version:** 4.12
      * **POM Project URL:** [http://junit.org](http://junit.org)
@@ -154,8 +150,6 @@
      * **POM License: New BSD License** - [http://www.opensource.org/licenses/bsd-license.php](http://www.opensource.org/licenses/bsd-license.php)
 
 1. **Group:** org.hsqldb **Name:** hsqldb **Version:** 2.3.3
-     * **POM Project URL:** [http://hsqldb.org](http://hsqldb.org)
-     * **POM License: HSQLDB License, a BSD open source license** - [http://hsqldb.org/web/hsqlLicense.html](http://hsqldb.org/web/hsqlLicense.html)
 
 1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
@@ -298,8 +292,6 @@
 
 1. **Group:** com.h2database **Name:** h2 **Version:** 1.4.196
      * **Manifest license URL:** [http://www.h2database.com/html/license.html](http://www.h2database.com/html/license.html)
-     * **POM Project URL:** [http://www.h2database.com](http://www.h2database.com)
-     * **POM License: MPL 2.0 or EPL 1.0** - [http://h2database.com/html/license.html](http://h2database.com/html/license.html)
 
 1. **Group:** com.infradna.tool **Name:** bridge-method-annotation **Version:** 1.13
      * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
@@ -348,8 +340,6 @@
 
 1. **Group:** joda-time **Name:** joda-time **Version:** 1.6
      * **Manifest License:** Apache 2.0 (Not packaged)
-     * **POM Project URL:** [http://joda-time.sourceforge.net](http://joda-time.sourceforge.net)
-     * **POM License: Apache 2** - [http://www.apache.org/licenses/](http://www.apache.org/licenses/)
 
 1. **Group:** junit **Name:** junit **Version:** 4.12
      * **POM Project URL:** [http://junit.org](http://junit.org)
@@ -426,8 +416,6 @@
      * **POM License: New BSD License** - [http://www.opensource.org/licenses/bsd-license.php](http://www.opensource.org/licenses/bsd-license.php)
 
 1. **Group:** org.hsqldb **Name:** hsqldb **Version:** 2.3.3
-     * **POM Project URL:** [http://hsqldb.org](http://hsqldb.org)
-     * **POM License: HSQLDB License, a BSD open source license** - [http://hsqldb.org/web/hsqlLicense.html](http://hsqldb.org/web/hsqlLicense.html)
 
 1. **Group:** org.jacoco **Name:** org.jacoco.agent **Version:** 0.8.4
      * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
@@ -516,4 +504,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Sep 01 21:48:00 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Sep 16 11:36:23 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -504,4 +504,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 16 11:36:23 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Sep 16 12:13:52 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -77,6 +77,8 @@
 
 1. **Group:** com.h2database **Name:** h2 **Version:** 1.4.196
      * **Manifest license URL:** [http://www.h2database.com/html/license.html](http://www.h2database.com/html/license.html)
+     * **POM Project URL:** [http://www.h2database.com](http://www.h2database.com)
+     * **POM License: MPL 2.0 or EPL 1.0** - [http://h2database.com/html/license.html](http://h2database.com/html/license.html)
 
 1. **Group:** com.infradna.tool **Name:** bridge-method-annotation **Version:** 1.13
      * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
@@ -108,6 +110,8 @@
 
 1. **Group:** joda-time **Name:** joda-time **Version:** 1.6
      * **Manifest License:** Apache 2.0 (Not packaged)
+     * **POM Project URL:** [http://joda-time.sourceforge.net](http://joda-time.sourceforge.net)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/](http://www.apache.org/licenses/)
 
 1. **Group:** junit **Name:** junit **Version:** 4.12
      * **POM Project URL:** [http://junit.org](http://junit.org)
@@ -150,6 +154,8 @@
      * **POM License: New BSD License** - [http://www.opensource.org/licenses/bsd-license.php](http://www.opensource.org/licenses/bsd-license.php)
 
 1. **Group:** org.hsqldb **Name:** hsqldb **Version:** 2.3.3
+     * **POM Project URL:** [http://hsqldb.org](http://hsqldb.org)
+     * **POM License: HSQLDB License, a BSD open source license** - [http://hsqldb.org/web/hsqlLicense.html](http://hsqldb.org/web/hsqlLicense.html)
 
 1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
@@ -292,6 +298,8 @@
 
 1. **Group:** com.h2database **Name:** h2 **Version:** 1.4.196
      * **Manifest license URL:** [http://www.h2database.com/html/license.html](http://www.h2database.com/html/license.html)
+     * **POM Project URL:** [http://www.h2database.com](http://www.h2database.com)
+     * **POM License: MPL 2.0 or EPL 1.0** - [http://h2database.com/html/license.html](http://h2database.com/html/license.html)
 
 1. **Group:** com.infradna.tool **Name:** bridge-method-annotation **Version:** 1.13
      * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
@@ -340,6 +348,8 @@
 
 1. **Group:** joda-time **Name:** joda-time **Version:** 1.6
      * **Manifest License:** Apache 2.0 (Not packaged)
+     * **POM Project URL:** [http://joda-time.sourceforge.net](http://joda-time.sourceforge.net)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/](http://www.apache.org/licenses/)
 
 1. **Group:** junit **Name:** junit **Version:** 4.12
      * **POM Project URL:** [http://junit.org](http://junit.org)
@@ -416,6 +426,8 @@
      * **POM License: New BSD License** - [http://www.opensource.org/licenses/bsd-license.php](http://www.opensource.org/licenses/bsd-license.php)
 
 1. **Group:** org.hsqldb **Name:** hsqldb **Version:** 2.3.3
+     * **POM Project URL:** [http://hsqldb.org](http://hsqldb.org)
+     * **POM License: HSQLDB License, a BSD open source license** - [http://hsqldb.org/web/hsqlLicense.html](http://hsqldb.org/web/hsqlLicense.html)
 
 1. **Group:** org.jacoco **Name:** org.jacoco.agent **Version:** 0.8.4
      * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
@@ -504,4 +516,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 16 12:13:52 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Sep 16 14:25:56 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>jdbc-storage</artifactId>
-<version>1.0.3</version>
+<version>1.1.0</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -70,13 +70,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>1.0.3</version>
+    <version>1.1.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>1.0.3</version>
+    <version>1.1.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -112,7 +112,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.0.3</version>
+    <version>1.1.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/JdbcStorageFactory.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/JdbcStorageFactory.java
@@ -114,6 +114,9 @@ public class JdbcStorageFactory implements StorageFactory {
         return storage;
     }
 
+    /**
+     * Creates a new storage for work session records based on JDBC.
+     */
     public JdbcSessionStorage createSessionStorage() {
         return JdbcSessionStorage
                 .newBuilder()

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/JdbcStorageFactory.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/JdbcStorageFactory.java
@@ -34,6 +34,7 @@ import io.spine.server.projection.ProjectionStorage;
 import io.spine.server.storage.StorageFactory;
 import io.spine.server.storage.jdbc.aggregate.JdbcAggregateStorage;
 import io.spine.server.storage.jdbc.delivery.JdbcInboxStorage;
+import io.spine.server.storage.jdbc.delivery.JdbcSessionStorage;
 import io.spine.server.storage.jdbc.projection.JdbcProjectionStorage;
 import io.spine.server.storage.jdbc.record.JdbcRecordStorage;
 import io.spine.server.storage.jdbc.type.JdbcColumnType;
@@ -111,6 +112,14 @@ public class JdbcStorageFactory implements StorageFactory {
                 .setTypeMapping(typeMapping)
                 .build();
         return storage;
+    }
+
+    public JdbcSessionStorage createSessionStorage() {
+        return JdbcSessionStorage
+                .newBuilder()
+                .setDataSource(dataSource)
+                .setTypeMapping(typeMapping)
+                .build();
     }
 
     /**

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/StorageBuilder.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/StorageBuilder.java
@@ -61,7 +61,7 @@ public abstract class StorageBuilder<B extends StorageBuilder<B, S>, S extends S
         return getThis();
     }
 
-    public DataSourceWrapper getDataSource() {
+    public DataSourceWrapper dataSource() {
         return dataSource;
     }
 
@@ -76,7 +76,7 @@ public abstract class StorageBuilder<B extends StorageBuilder<B, S>, S extends S
         return getThis();
     }
 
-    public TypeMapping getTypeMapping() {
+    public TypeMapping typeMapping() {
         return typeMapping;
     }
 

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorage.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorage.java
@@ -82,8 +82,8 @@ public class JdbcAggregateStorage<I> extends AggregateStorage<I> {
     protected JdbcAggregateStorage(Builder<I> builder) {
         super(builder.isMultitenant());
         Class<? extends Aggregate<I, ?, ?>> aggregateClass = builder.getAggregateClass();
-        TypeMapping mapping = builder.getTypeMapping();
-        this.dataSource = builder.getDataSource();
+        TypeMapping mapping = builder.typeMapping();
+        this.dataSource = builder.dataSource();
         this.mainTable = new AggregateEventRecordTable<>(aggregateClass, dataSource, mapping);
         this.lifecycleFlagsTable = new LifecycleFlagsTable<>(aggregateClass, dataSource, mapping);
         mainTable.create();

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/JdbcInboxStorage.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/JdbcInboxStorage.java
@@ -50,9 +50,9 @@ public class JdbcInboxStorage
     private final DataSourceWrapper dataSource;
 
     private JdbcInboxStorage(Builder builder) {
-        super(builder.isMultitenant(), new InboxTable(builder.getDataSource(),
-                                                      builder.getTypeMapping()));
-        this.dataSource = builder.getDataSource();
+        super(builder.isMultitenant(), new InboxTable(builder.dataSource(),
+                                                      builder.typeMapping()));
+        this.dataSource = builder.dataSource();
     }
 
     /**

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/JdbcSessionStorage.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/JdbcSessionStorage.java
@@ -29,7 +29,6 @@ import io.spine.server.storage.jdbc.message.JdbcMessageStorage;
 
 import java.util.Iterator;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.util.Exceptions.unsupported;
 
 /**
@@ -50,10 +49,7 @@ public class JdbcSessionStorage
     }
 
     protected JdbcSessionStorage(DataSourceWrapper dataSource, TypeMapping typeMapping) {
-        super(true, new ShardedWorkRegistryTable(
-                checkNotNull(dataSource),
-                checkNotNull(typeMapping)
-        ));
+        super(true, new ShardedWorkRegistryTable(dataSource, typeMapping));
     }
 
     /**

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/JdbcSessionStorage.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/JdbcSessionStorage.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.jdbc.delivery;
+
+import io.spine.server.delivery.ShardIndex;
+import io.spine.server.delivery.ShardSessionRecord;
+import io.spine.server.storage.jdbc.StorageBuilder;
+import io.spine.server.storage.jdbc.message.JdbcMessageStorage;
+
+import java.util.Iterator;
+
+import static io.spine.util.Exceptions.unsupported;
+
+public final class JdbcSessionStorage extends JdbcMessageStorage<ShardIndex,
+                                                          ShardSessionRecord,
+                                                          ShardSessionReadRequest,
+                                                          ShardedWorkRegistryTable> {
+
+    private JdbcSessionStorage(Builder builder) {
+        super(false, new ShardedWorkRegistryTable(builder.dataSource(), builder.typeMapping()));
+    }
+
+    /**
+     * Obtains all the session records present in the storage.
+     */
+    Iterator<ShardSessionRecord> readAll() {
+        return table().readAll();
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder extends StorageBuilder<Builder, JdbcSessionStorage> {
+
+        /**
+         * Prevents direct instantiation.
+         */
+        private Builder() {
+            super();
+        }
+
+        @Override
+        public Builder setMultitenant(boolean multitenant) {
+            throw unsupported("`JdbcShardedWorkRegistry` is an application-wide instance " +
+                                      "and therefore is always single-tenant");
+        }
+
+        @Override
+        protected Builder getThis() {
+            return this;
+        }
+
+        @Override
+        protected JdbcSessionStorage doBuild() {
+            return new JdbcSessionStorage(this);
+        }
+    }
+}

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/JdbcShardedWorkRegistry.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/JdbcShardedWorkRegistry.java
@@ -47,6 +47,12 @@ public class JdbcShardedWorkRegistry
 
     private final JdbcSessionStorage storage;
 
+    /**
+     * Creates a new registry.
+     *
+     * @param storageFactory
+     *         the storage factory for creating a storage for this registry
+     */
     public JdbcShardedWorkRegistry(JdbcStorageFactory storageFactory) {
         super();
         checkNotNull(storageFactory);
@@ -61,8 +67,7 @@ public class JdbcShardedWorkRegistry
 
     private boolean pickedBy(ShardIndex index, NodeId nodeId) {
         Optional<ShardSessionRecord> stored = find(index);
-        return stored.map(record -> record.getPickedBy()
-                                          .equals(nodeId))
+        return stored.map(record -> record.getPickedBy().equals(nodeId))
                      .orElse(false);
     }
 

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/JdbcShardedWorkRegistry.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/JdbcShardedWorkRegistry.java
@@ -20,30 +20,20 @@
 
 package io.spine.server.storage.jdbc.delivery;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Duration;
-import com.google.protobuf.Timestamp;
-import com.google.protobuf.util.Durations;
 import io.spine.logging.Logging;
 import io.spine.server.NodeId;
+import io.spine.server.delivery.AbstractWorkRegistry;
 import io.spine.server.delivery.ShardIndex;
 import io.spine.server.delivery.ShardProcessingSession;
 import io.spine.server.delivery.ShardSessionRecord;
 import io.spine.server.delivery.ShardedWorkRegistry;
-import io.spine.server.storage.jdbc.StorageBuilder;
-import io.spine.server.storage.jdbc.message.JdbcMessageStorage;
-import io.spine.string.Stringifiers;
+import io.spine.server.storage.jdbc.JdbcStorageFactory;
 
 import java.util.Iterator;
-import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.Streams.stream;
-import static com.google.protobuf.util.Timestamps.between;
-import static io.spine.base.Time.currentTime;
-import static io.spine.util.Exceptions.unsupported;
 
 /**
  * A JDBC-based implementation of the {@link ShardedWorkRegistry}.
@@ -52,131 +42,53 @@ import static io.spine.util.Exceptions.unsupported;
  * appropriate accessor methods.
  */
 public class JdbcShardedWorkRegistry
-        extends JdbcMessageStorage<ShardIndex,
-                                   ShardSessionRecord,
-                                   ShardSessionReadRequest,
-                                   ShardedWorkRegistryTable>
-        implements ShardedWorkRegistry, Logging {
+        extends AbstractWorkRegistry
+        implements Logging {
 
-    private JdbcShardedWorkRegistry(Builder builder) {
-        super(false,
-              new ShardedWorkRegistryTable(builder.getDataSource(), builder.getTypeMapping()));
+    private final JdbcSessionStorage storage;
+
+    public JdbcShardedWorkRegistry(JdbcStorageFactory storageFactory) {
+        super();
+        checkNotNull(storageFactory);
+        this.storage = storageFactory.createSessionStorage();
     }
 
     @Override
     public synchronized Optional<ShardProcessingSession> pickUp(ShardIndex index, NodeId nodeId) {
-        checkNotNull(index);
-        checkNotNull(nodeId);
-        checkNotClosed();
+        Optional<ShardProcessingSession> picked = super.pickUp(index, nodeId);
+        return picked.filter(session -> pickedBy(index, nodeId));
+    }
 
-        boolean pickedAlready = isPickedAlready(index);
-        if (pickedAlready) {
-            return Optional.empty();
-        }
-        ShardSessionRecord ssr = newRecord(index, nodeId);
-        write(ssr);
-
-        boolean writeConsistent = checkConsistency(index, ssr);
-        if (writeConsistent) {
-            ShardProcessingSession result = new JdbcShardProcessingSession(ssr, () -> clearNode(ssr));
-            return Optional.of(result);
-        } else {
-            return Optional.empty();
-        }
+    private boolean pickedBy(ShardIndex index, NodeId nodeId) {
+        Optional<ShardSessionRecord> stored = find(index);
+        return stored.map(record -> record.getPickedBy()
+                                          .equals(nodeId))
+                     .orElse(false);
     }
 
     @Override
-    public Iterable<ShardIndex> releaseExpiredSessions(Duration inactivityPeriod) {
-        checkNotNull(inactivityPeriod);
-
-        ImmutableList<ShardSessionRecord> allRecords =  ImmutableList.copyOf(readAll());
-        ImmutableList.Builder<ShardIndex> resultBuilder = ImmutableList.builder();
-        for (ShardSessionRecord record : allRecords) {
-            Timestamp whenPicked = record.getWhenLastPicked();
-            Duration elapsed = between(whenPicked, currentTime());
-
-            int comparison = Durations.compare(elapsed, inactivityPeriod);
-            if (comparison >= 0) {
-                clearNode(record);
-                resultBuilder.add(record.getIndex());
-            }
-        }
-        return resultBuilder.build();
+    public synchronized Iterable<ShardIndex> releaseExpiredSessions(Duration inactivityPeriod) {
+        return super.releaseExpiredSessions(inactivityPeriod);
     }
 
-    private boolean checkConsistency(ShardIndex index, ShardSessionRecord ssr) {
-        List<ShardSessionRecord> records = ImmutableList.copyOf(readByIndex(index));
-        if (records.size() > 1) {
-            _warn().log("Several `ShardSessionRecord`s found for index %s.",
-                        Stringifiers.toString(index));
-        }
-        ShardSessionRecord fromStorage = records.iterator()
-                                                .next();
-        return fromStorage.equals(ssr);
+    @Override
+    protected Iterator<ShardSessionRecord> allRecords() {
+        return storage.readAll();
     }
 
-    /**
-     * Tells if the session with the passed index is currently picked by any node.
-     */
-    private boolean isPickedAlready(ShardIndex index) {
-        Iterator<ShardSessionRecord> records = readByIndex(index);
-        long nodesWithShard = stream(records)
-                .filter(ShardSessionRecord::hasPickedBy)
-                .count();
-        return nodesWithShard > 0;
+    @Override
+    protected void write(ShardSessionRecord session) {
+        storage.write(session.getIndex(), session);
     }
 
-    /**
-     * Reads all messages belonging to a {@linkplain ShardIndex#getIndex() shard index}.
-     */
-    @VisibleForTesting
-    Iterator<ShardSessionRecord> readByIndex(ShardIndex index) {
-        return table().readByIndex(index);
+    @Override
+    protected Optional<ShardSessionRecord> find(ShardIndex index) {
+        ShardSessionReadRequest request = new ShardSessionReadRequest(index);
+        return storage.read(request);
     }
 
-    /**
-     * Reads all messages from the storage.
-     */
-    private Iterator<ShardSessionRecord> readAll() {
-        return table().readAll();
-    }
-
-
-    private static ShardSessionRecord newRecord(ShardIndex index, NodeId nodeId) {
-        return ShardSessionRecord.newBuilder()
-                                 .setIndex(index)
-                                 .setPickedBy(nodeId)
-                                 .setWhenLastPicked(currentTime())
-                                 .vBuild();
-    }
-
-    private void clearNode(ShardSessionRecord record) {
-        ShardSessionRecord updated = record.toBuilder()
-                                           .clearPickedBy()
-                                           .vBuild();
-        write(updated);
-    }
-
-    public static Builder newBuilder() {
-        return new Builder();
-    }
-
-    public static class Builder extends StorageBuilder<Builder, JdbcShardedWorkRegistry> {
-
-        @Override
-        public Builder setMultitenant(boolean multitenant) {
-            throw unsupported("`JdbcShardedWorkRegistry` is an application-wide instance " +
-                              "and therefore is always single-tenant");
-        }
-
-        @Override
-        protected Builder getThis() {
-            return this;
-        }
-
-        @Override
-        protected JdbcShardedWorkRegistry doBuild() {
-            return new JdbcShardedWorkRegistry(this);
-        }
+    @Override
+    protected ShardProcessingSession asSession(ShardSessionRecord record) {
+        return new JdbcShardProcessingSession(record, () -> clearNode(record));
     }
 }

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/ShardedWorkRegistryTable.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/ShardedWorkRegistryTable.java
@@ -42,9 +42,6 @@ import static io.spine.server.storage.jdbc.Type.STRING_255;
  *
  * <p>The {@link ShardIndex} message is used as an ID for records, so there can be multiple session
  * records per shard index {@linkplain ShardIndex#getIndex() itself}.
- *
- * <p>The {@link #readByIndex(ShardIndex)} method can be used to retrieve items belonging to a
- * concrete {@linkplain ShardIndex#getIndex() shard index}.
  */
 final class ShardedWorkRegistryTable extends MessageTable<ShardIndex, ShardSessionRecord> {
 
@@ -65,34 +62,12 @@ final class ShardedWorkRegistryTable extends MessageTable<ShardIndex, ShardSessi
     }
 
     /**
-     * Obtains all session records belonging to a given shard index.
-     *
-     * <p>Record filtering is based on the {@link Column#SHARD_INDEX} column which represents the
-     * shard index {@linkplain ShardIndex#getIndex() value} itself.
-     */
-    Iterator<ShardSessionRecord> readByIndex(ShardIndex index) {
-        SelectShardSessionsByShardIndex query = selectByIndex(index);
-        Iterator<ShardSessionRecord> iterator = query.execute();
-        return iterator;
-    }
-
-    /**
      * Obtains all session records.
      */
     Iterator<ShardSessionRecord> readAll() {
         SelectAllShardSessions query = selectAll();
         Iterator<ShardSessionRecord> iterator = query.execute();
         return iterator;
-    }
-
-    private SelectShardSessionsByShardIndex selectByIndex(ShardIndex index) {
-        SelectShardSessionsByShardIndex.Builder builder =
-                SelectShardSessionsByShardIndex.newBuilder();
-        SelectShardSessionsByShardIndex query = builder.setTableName(name())
-                                                       .setDataSource(dataSource())
-                                                       .setShardIndex(index)
-                                                       .build();
-        return query;
     }
 
     private SelectAllShardSessions selectAll() {

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/projection/JdbcProjectionStorage.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/projection/JdbcProjectionStorage.java
@@ -64,8 +64,8 @@ public class JdbcProjectionStorage<I> extends ProjectionStorage<I> {
         this.recordStorage = builder.getRecordStorage();
         this.projectionId = builder.getProjectionClass()
                                    .getName();
-        this.table = new LastHandledEventTimeTable(builder.getDataSource(),
-                                                   builder.getTypeMapping());
+        this.table = new LastHandledEventTimeTable(builder.dataSource(),
+                                                   builder.typeMapping());
         table.create();
     }
 

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/record/JdbcRecordStorage.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/record/JdbcRecordStorage.java
@@ -72,11 +72,11 @@ public class JdbcRecordStorage<I> extends RecordStorage<I> {
      */
     protected JdbcRecordStorage(Builder<I> builder) throws DatabaseException {
         super(builder.isMultitenant(), builder.getEntityClass());
-        this.dataSource = builder.getDataSource();
+        this.dataSource = builder.dataSource();
         Class<? extends Entity<I, ?>> entityClass = builder.getEntityClass();
         Collection<EntityColumn> entityColumns = entityColumnCache().getColumns();
         this.table = new RecordTable<>(entityClass, dataSource, builder.getColumnTypeRegistry(),
-                                       builder.getTypeMapping(), entityColumns);
+                                       builder.typeMapping(), entityColumns);
         table.create();
     }
 

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcSessionStorageTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcSessionStorageTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.jdbc.delivery;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("JdbcSessionStorage should")
+class JdbcSessionStorageTest {
+
+    @Test
+    @DisplayName("not allow changing tenancy attribute")
+    void notAllowSingleTenant() {
+        JdbcSessionStorage.Builder builder = JdbcSessionStorage.newBuilder();
+        assertThrows(UnsupportedOperationException.class,
+                     () -> builder.setMultitenant(false));
+    }
+}

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcShardedWorkRegistryTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcShardedWorkRegistryTest.java
@@ -40,10 +40,12 @@ import java.util.Optional;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
+import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
 import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
 import static io.spine.server.storage.jdbc.delivery.given.TestShardIndex.newIndex;
 import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -131,6 +133,11 @@ class JdbcShardedWorkRegistryTest extends ShardedWorkRegistryTest {
 
         ShardSessionRecord completedRecord = readSingleRecord(index);
         assertFalse(completedRecord.hasPickedBy());
+
+        // On some platforms (namely some Windows distributions), Java cannot obtain current time
+        // with enough precision to compare timestamps in this test. By waiting for 1 second, we
+        // ensure that the timestamps will not accidentally be identical.
+        sleepUninterruptibly(1, SECONDS);
 
         NodeId anotherNode = newNode();
         Optional<ShardProcessingSession> anotherOptional = registry.pickUp(index, anotherNode);

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcShardedWorkRegistryTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcShardedWorkRegistryTest.java
@@ -31,14 +31,15 @@ import io.spine.server.delivery.ShardSessionRecord;
 import io.spine.server.delivery.ShardedWorkRegistry;
 import io.spine.server.delivery.ShardedWorkRegistryTest;
 import io.spine.server.storage.jdbc.DataSourceWrapper;
+import io.spine.server.storage.jdbc.JdbcStorageFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Iterator;
 import java.util.Optional;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
 import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
 import static io.spine.server.storage.jdbc.delivery.given.TestShardIndex.newIndex;
@@ -58,11 +59,12 @@ class JdbcShardedWorkRegistryTest extends ShardedWorkRegistryTest {
     @BeforeEach
     void setUp() {
         DataSourceWrapper dataSource = whichIsStoredInMemory("jdbcShardedWorkRegistryTest");
-        registry = JdbcShardedWorkRegistry
+        JdbcStorageFactory storageFactory = JdbcStorageFactory
                 .newBuilder()
                 .setDataSource(dataSource)
                 .setTypeMapping(MYSQL_5_7)
                 .build();
+        registry = new JdbcShardedWorkRegistry(storageFactory);
     }
 
     @Override
@@ -98,7 +100,6 @@ class JdbcShardedWorkRegistryTest extends ShardedWorkRegistryTest {
     @Test
     @DisplayName("not be able to pick up the shard if it's already picked up")
     void cannotPickUpIfTaken() {
-
         Optional<ShardProcessingSession> session = registry.pickUp(index, nodeId);
         assertTrue(session.isPresent());
 
@@ -143,10 +144,10 @@ class JdbcShardedWorkRegistryTest extends ShardedWorkRegistryTest {
     }
 
     private ShardSessionRecord readSingleRecord(ShardIndex index) {
-        Iterator<ShardSessionRecord> records = registry.readByIndex(index);
-        assertTrue(records.hasNext());
+        Optional<ShardSessionRecord> record = registry.find(index);
+        assertThat(record).isPresent();
 
-        return records.next();
+        return record.get();
     }
 
     private static NodeId newNode() {

--- a/version.gradle
+++ b/version.gradle
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-final def SPINE_VERSION = '1.0.3'
+final def SPINE_VERSION = '1.1.0'
 
 ext {
     versionToPublish = SPINE_VERSION


### PR DESCRIPTION
This PR updates the library to version 1.1.0.

The changes in the `ShardSessionRegistry` are propagated from `core` to `jdbc-storage`.
Also, the storage for session records is now always _multitenant_, not always _single-tenant_ for consistency with other storages.