### PR TITLE
Remove Mockito

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,7 @@ subprojects {
                 classifier: 'test', excludes
 
         testImplementation group: 'io.spine', name: 'spine-testlib', version: spineBaseVersion
+        testImplementation "io.spine.tools:spine-mute-logging:$spineBaseVersion"
 
         errorprone deps.build.errorProneCore
         errorproneJavac deps.build.errorProneJavac

--- a/build.gradle
+++ b/build.gradle
@@ -90,11 +90,7 @@ subprojects {
         implementation deps.build.errorProneAnnotations
         implementation deps.build.slf4j
 
-        testImplementation deps.test.junit5Api
         testImplementation deps.test.junit5Runner
-        testImplementation deps.test.hamcrest
-        testImplementation deps.test.mockito
-        testImplementation deps.test.guavaTestlib
     }
 
     test {

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-rdbms:1.1.0`
+# Dependencies of `io.spine:spine-rdbms:1.1.1-SNAPSHOT+1`
 
 ## Runtime
 1. **Group:** com.google.auto.value **Name:** auto-value-annotations **Version:** 1.6.3
@@ -117,14 +117,6 @@
      * **POM Project URL:** [http://junit.org](http://junit.org)
      * **POM License: Eclipse Public License 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
-1. **Group:** net.bytebuddy **Name:** byte-buddy **Version:** 1.7.9
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** net.bytebuddy **Name:** byte-buddy-agent **Version:** 1.7.9
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** org.apache.servicemix.bundles **Name:** org.apache.servicemix.bundles.javax-inject **Version:** 1_2
      * **Manifest Project URL:** [http://www.apache.org/](http://www.apache.org/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -168,15 +160,6 @@
 1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
-
-1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
-     * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
-     * **POM License: The MIT License** - [https://github.com/mockito/mockito/blob/master/LICENSE](https://github.com/mockito/mockito/blob/master/LICENSE)
-
-1. **Group:** org.objenesis **Name:** objenesis **Version:** 2.6
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM Project URL:** [http://objenesis.org](http://objenesis.org)
-     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** org.opentest4j **Name:** opentest4j **Version:** 1.2.0
      * **Manifest License:** The Apache License, Version 2.0 (Not packaged)
@@ -355,14 +338,6 @@
      * **POM Project URL:** [http://junit.org](http://junit.org)
      * **POM License: Eclipse Public License 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
-1. **Group:** net.bytebuddy **Name:** byte-buddy **Version:** 1.7.9
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** net.bytebuddy **Name:** byte-buddy-agent **Version:** 1.7.9
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** net.java.dev.javacc **Name:** javacc **Version:** 5.0
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
@@ -465,15 +440,6 @@
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
-     * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
-     * **POM License: The MIT License** - [https://github.com/mockito/mockito/blob/master/LICENSE](https://github.com/mockito/mockito/blob/master/LICENSE)
-
-1. **Group:** org.objenesis **Name:** objenesis **Version:** 2.6
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM Project URL:** [http://objenesis.org](http://objenesis.org)
-     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** org.opentest4j **Name:** opentest4j **Version:** 1.2.0
      * **Manifest License:** The Apache License, Version 2.0 (Not packaged)
      * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
@@ -516,4 +482,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 16 14:25:56 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 18 13:53:01 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -516,4 +516,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Sep 01 21:48:00 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 17 15:06:16 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -516,4 +516,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Sep 17 15:06:16 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 17 20:49:56 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -482,4 +482,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 18 16:30:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 18 17:15:46 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -516,4 +516,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Sep 17 20:49:56 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 18 13:44:58 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -482,4 +482,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 18 13:53:01 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 18 15:33:34 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -482,4 +482,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 18 15:33:34 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 18 16:30:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@ all modules and does not describe the project structure per-subproject.
     <scope>test</scope>
   </dependency>
   <dependency>
+    <groupId>io.spine.tools</groupId>
+    <artifactId>spine-mute-logging</artifactId>
+    <version>1.0.3</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
     <groupId>org.apiguardian</groupId>
     <artifactId>apiguardian-api</artifactId>
     <version>1.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>jdbc-storage</artifactId>
-<version>1.1.0</version>
+<version>1.1.1-SNAPSHOT+1</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -70,13 +70,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT+1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT+1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -98,12 +98,6 @@ all modules and does not describe the project structure per-subproject.
     <scope>compile</scope>
   </dependency>
   <dependency>
-    <groupId>com.google.guava</groupId>
-    <artifactId>guava-testlib</artifactId>
-    <version>28.1-jre</version>
-    <scope>test</scope>
-  </dependency>
-  <dependency>
     <groupId>io.grpc</groupId>
     <artifactId>grpc-stub</artifactId>
     <version>1.22.0</version>
@@ -118,43 +112,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.0.3</version>
-    <scope>test</scope>
-  </dependency>
-  <dependency>
-    <groupId>org.apiguardian</groupId>
-    <artifactId>apiguardian-api</artifactId>
-    <version>1.0.0</version>
-    <scope>test</scope>
-  </dependency>
-  <dependency>
-    <groupId>org.hamcrest</groupId>
-    <artifactId>hamcrest-all</artifactId>
-    <version>1.3</version>
-    <scope>test</scope>
-  </dependency>
-  <dependency>
-    <groupId>org.junit.jupiter</groupId>
-    <artifactId>junit-jupiter-api</artifactId>
-    <version>5.5.1</version>
+    <version>1.1.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-engine</artifactId>
     <version>5.5.1</version>
-    <scope>test</scope>
-  </dependency>
-  <dependency>
-    <groupId>org.junit.jupiter</groupId>
-    <artifactId>junit-jupiter-params</artifactId>
-    <version>5.5.1</version>
-    <scope>test</scope>
-  </dependency>
-  <dependency>
-    <groupId>org.mockito</groupId>
-    <artifactId>mockito-core</artifactId>
-    <version>2.12.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/rdbms/build.gradle
+++ b/rdbms/build.gradle
@@ -38,6 +38,5 @@ dependencies {
         exclude group: 'com.google.guava'
     }
 
-    testImplementation deps.test.mockito
     testImplementation deps.grpc.grpcStub
 }

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/ConnectionWrapper.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/ConnectionWrapper.java
@@ -29,6 +29,7 @@ import java.sql.SQLException;
 /**
  * The wrapper for {@link Connection} instances.
  */
+// TODO:2019-09-17:dmytro.kuzmin:WIP: Make `final` when all mocks are gone.
 @Internal
 public class ConnectionWrapper implements AutoCloseable {
 

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/ConnectionWrapper.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/ConnectionWrapper.java
@@ -29,9 +29,8 @@ import java.sql.SQLException;
 /**
  * The wrapper for {@link Connection} instances.
  */
-// TODO:2019-09-17:dmytro.kuzmin:WIP: Make `final` when all mocks are gone.
 @Internal
-public class ConnectionWrapper implements AutoCloseable {
+public final class ConnectionWrapper implements AutoCloseable {
 
     private final Connection connection;
 

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/DataSourceMetaData.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/DataSourceMetaData.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.jdbc;
+
+import io.spine.annotation.Internal;
+
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+
+/**
+ * A meta data of the {@linkplain javax.sql.DataSource data source}.
+ */
+@Internal
+public interface DataSourceMetaData {
+
+    /**
+     * Obtains the database product name.
+     */
+    String productName();
+
+    /**
+     * Obtains the database major version number.
+     */
+    int majorVersion();
+
+    /**
+     * Obtains the database minor version number.
+     */
+    int minorVersion();
+
+    /**
+     * Wraps a given database {@linkplain DatabaseMetaData meta data}.
+     *
+     * @throws DatabaseException
+     *         in case something went wrong when interacting with database
+     */
+    static DataSourceMetaData of(DatabaseMetaData metaData) throws DatabaseException {
+        try {
+            String productName = metaData.getDatabaseProductName();
+            int majorVersion = metaData.getDatabaseMajorVersion();
+            int minorVersion = metaData.getDatabaseMinorVersion();
+
+            return new DataSourceMetaData() {
+                @Override
+                public String productName() {
+                    return productName;
+                }
+
+                @Override
+                public int majorVersion() {
+                    return majorVersion;
+                }
+
+                @Override
+                public int minorVersion() {
+                    return minorVersion;
+                }
+            };
+        } catch (SQLException e) {
+            throw new DatabaseException(e);
+        }
+    }
+}

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/DataSourceMetaData.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/DataSourceMetaData.java
@@ -26,7 +26,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 
 /**
- * A meta data of the {@linkplain javax.sql.DataSource data source}.
+ * A metadata of the {@linkplain javax.sql.DataSource data source}.
  */
 @Internal
 public interface DataSourceMetaData {
@@ -47,7 +47,7 @@ public interface DataSourceMetaData {
     int minorVersion();
 
     /**
-     * Wraps a given database {@linkplain DatabaseMetaData meta data}.
+     * Wraps a given database {@linkplain DatabaseMetaData metadata}.
      *
      * @throws DatabaseException
      *         in case something went wrong when interacting with database

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/DataSourceWrapper.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/DataSourceWrapper.java
@@ -65,6 +65,9 @@ public interface DataSourceWrapper extends AutoCloseable {
     @Override
     void close();
 
+    /**
+     * Returns {@code true} if the data source is closed, {@code false} otherwise.
+     */
     boolean isClosed();
 
     /** Wraps a {@link DataSource} implementation. */

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/DataSourceWrapper.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/DataSourceWrapper.java
@@ -36,6 +36,8 @@ public interface DataSourceWrapper extends AutoCloseable {
      *
      * @throws DatabaseException
      *         if an error occurs during an interaction with the DB
+     * @throws IllegalStateException
+     *         if the data source is closed
      * @see Connection#setAutoCommit(boolean)
      */
     ConnectionWrapper getConnection(boolean autoCommit) throws DatabaseException;
@@ -45,16 +47,25 @@ public interface DataSourceWrapper extends AutoCloseable {
      *
      * @throws DatabaseException
      *         if an error occurs during an interaction with the DB
+     * @throws IllegalStateException
+     *         if the data source is closed
      */
     DataSourceMetaData metaData() throws DatabaseException;
 
     /**
      * Closes the wrapped {@link DataSource}.
      *
-     * <p>Overridden from {@link AutoCloseable} to narrow down the thrown exception type.
+     * <p>Overridden from {@link AutoCloseable} to get rid of thrown exception type.
+     *
+     * @throws DatabaseException
+     *         if an error occurs during an interaction with the DB
+     * @throws IllegalStateException
+     *         if the data source is closed
      */
     @Override
-    void close() throws DatabaseException;
+    void close();
+
+    boolean isClosed();
 
     /** Wraps a {@link DataSource} implementation. */
     static DataSourceWrapper wrap(DataSource dataSource) {

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/DataSourceWrapper.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/DataSourceWrapper.java
@@ -43,7 +43,7 @@ public interface DataSourceWrapper extends AutoCloseable {
     ConnectionWrapper getConnection(boolean autoCommit) throws DatabaseException;
 
     /**
-     * Obtains the meta data of the wrapped {@link DataSource}.
+     * Obtains the metadata of the wrapped {@link DataSource}.
      *
      * @throws DatabaseException
      *         if an error occurs during an interaction with the DB

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/DataSourceWrapper.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/DataSourceWrapper.java
@@ -43,7 +43,7 @@ public interface DataSourceWrapper extends AutoCloseable {
     ConnectionWrapper getConnection(boolean autoCommit) throws DatabaseException;
 
     /**
-     * Obtains the meta data like product name and version of the wrapped {@link DataSource}.
+     * Obtains the meta data of the wrapped {@link DataSource}.
      *
      * @throws DatabaseException
      *         if an error occurs during an interaction with the DB

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/DefaultDataSourceWrapper.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/DefaultDataSourceWrapper.java
@@ -62,7 +62,6 @@ final class DefaultDataSourceWrapper implements DataSourceWrapper, Logging {
             DatabaseMetaData metaData = connection.get()
                                                   .getMetaData();
             return DataSourceMetaData.of(metaData);
-
         } catch (SQLException e) {
             throw new DatabaseException(e);
         }

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/DefaultDataSourceWrapper.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/DefaultDataSourceWrapper.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.jdbc;
+
+import io.spine.logging.Logging;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+
+/**
+ * A default implementation of the {@link DataSourceWrapper}.
+ */
+// TODO:2019-09-17:dmytro.kuzmin:WIP: Make `final` when all mocks are gone.
+class DefaultDataSourceWrapper implements DataSourceWrapper, Logging {
+
+    private final DataSource dataSource;
+
+    DefaultDataSourceWrapper(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public ConnectionWrapper getConnection(boolean autoCommit) throws DatabaseException {
+        try {
+            Connection connection = dataSource.getConnection();
+            connection.setAutoCommit(autoCommit);
+            ConnectionWrapper wrapper = ConnectionWrapper.wrap(connection);
+            return wrapper;
+        } catch (SQLException e) {
+            _error().log("Failed to get connection: %s", e.getMessage());
+            throw new DatabaseException(e);
+        }
+    }
+
+    @Override
+    public DataSourceMetaData metaData() throws DatabaseException {
+        try (final ConnectionWrapper connection = getConnection(true)) {
+            DatabaseMetaData metaData = connection.get()
+                                                  .getMetaData();
+            return DataSourceMetaData.of(metaData);
+
+        } catch (SQLException e) {
+            throw new DatabaseException(e);
+        }
+    }
+
+    /**
+     * Closes wrapped {@link DataSource} implementation if it implements {@link AutoCloseable}.
+     *
+     * <p>Otherwise a warning is logged.
+     *
+     * @throws DatabaseException
+     *         if the {@link DataSource} throws an exception
+     */
+    @Override
+    public void close() throws DatabaseException {
+        if (dataSource instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) dataSource).close();
+            } catch (Exception e) {
+                _error().log("Error occurred while closing DataSource: %s", e.getMessage());
+                throw new DatabaseException(e);
+            }
+            return;
+        }
+        _warn().log("Close method is not implemented in %s", dataSource.getClass()
+                                                                       .getCanonicalName());
+    }
+}

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/DefaultDataSourceWrapper.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/DefaultDataSourceWrapper.java
@@ -32,8 +32,7 @@ import static com.google.common.base.Preconditions.checkState;
 /**
  * A default implementation of the {@link DataSourceWrapper}.
  */
-// TODO:2019-09-17:dmytro.kuzmin:WIP: Make `final` when all mocks are gone.
-class DefaultDataSourceWrapper implements DataSourceWrapper, Logging {
+final class DefaultDataSourceWrapper implements DataSourceWrapper, Logging {
 
     private final DataSource dataSource;
     private boolean isClosed;

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/PredefinedMapping.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/PredefinedMapping.java
@@ -34,7 +34,8 @@ import static io.spine.server.storage.jdbc.TypeMappingBuilder.basicBuilder;
 public enum PredefinedMapping implements TypeMapping {
 
     MYSQL_5_7("MySQL", 5, 7, basicBuilder()),
-    POSTGRESQL_10_1("PostgreSQL", 10, 1, basicBuilder().add(BYTE_ARRAY, "BYTEA"));
+    POSTGRESQL_10_1("PostgreSQL", 10, 1, basicBuilder().add(BYTE_ARRAY, "BYTEA")),
+    H2_1_4("H2", 1, 4, basicBuilder());
 
     @SuppressWarnings("NonSerializableFieldInSerializableClass")
     private final TypeMapping typeMapping;

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/PredefinedMapping.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/PredefinedMapping.java
@@ -59,8 +59,8 @@ public enum PredefinedMapping implements TypeMapping {
     /**
      * Selects the type mapping for the specified data source.
      *
-     * <p>The {@linkplain DataSourceMetaData#productName() database product name} and
-     * the version are taken into account during the selection.
+     * <p>The {@linkplain DataSourceMetaData#productName() database product name} and the version
+     * are taken into account during the selection.
      *
      * @param dataSource
      *         the data source to test suitability

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/message/MessageTable.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/message/MessageTable.java
@@ -20,7 +20,6 @@
 
 package io.spine.server.storage.jdbc.message;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import com.google.protobuf.Descriptors.Descriptor;
@@ -32,7 +31,6 @@ import io.spine.server.storage.jdbc.TypeMapping;
 import io.spine.server.storage.jdbc.query.AbstractTable;
 import io.spine.server.storage.jdbc.query.IdColumn;
 
-import java.sql.ResultSet;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -71,32 +69,6 @@ public abstract class MessageTable<I, M extends Message> extends AbstractTable<I
         SelectMessagesInBulk<I, M> query = composeSelectMessagesInBulkQuery(ids);
         Iterator<M> result = query.execute();
         return result;
-    }
-
-    /**
-     * Obtains a {@link ResultSet} over a given ID query.
-     *
-     * <p>A test-only method.
-     */
-    @VisibleForTesting
-    protected ResultSet resultSet(I id) {
-        SelectSingleMessage<I, M> query = composeSelectQuery(id);
-        ResultSet resultSet = query.query()
-                                   .getResults();
-        return resultSet;
-    }
-
-    /**
-     * Obtains a {@link ResultSet} over a given ID query.
-     *
-     * <p>A test-only method.
-     */
-    @VisibleForTesting
-    protected ResultSet resultSet(Iterable<I> ids) {
-        SelectMessagesInBulk<I, M> query = composeSelectMessagesInBulkQuery(ids);
-        ResultSet resultSet = query.query()
-                                   .getResults();
-        return resultSet;
     }
 
     /**

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/message/MessageTable.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/message/MessageTable.java
@@ -140,7 +140,7 @@ public abstract class MessageTable<I, M extends Message> extends AbstractTable<I
     protected abstract Descriptor messageDescriptor();
 
     @SuppressWarnings("unchecked") // Ensured by descendant classes declaration.
-    private I idOf(M record) {
+    protected I idOf(M record) {
         Column<M> column = (Column<M>) idColumn().column();
         I id = (I) column.getter()
                          .apply(record);

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/message/MessageTable.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/message/MessageTable.java
@@ -67,22 +67,32 @@ public abstract class MessageTable<I, M extends Message> extends AbstractTable<I
      *
      * <p>The non-existent IDs are ignored.
      */
-    public Iterator<M> readAll(Iterable<I> ids) {
+    protected Iterator<M> readAll(Iterable<I> ids) {
         SelectMessagesInBulk<I, M> query = composeSelectMessagesInBulkQuery(ids);
         Iterator<M> result = query.execute();
         return result;
     }
 
+    /**
+     * Obtains a {@link ResultSet} over a given ID query.
+     *
+     * <p>A test-only method.
+     */
     @VisibleForTesting
-    public ResultSet resultSet(I id) {
+    protected ResultSet resultSet(I id) {
         SelectSingleMessage<I, M> query = composeSelectQuery(id);
         ResultSet resultSet = query.query()
                                    .getResults();
         return resultSet;
     }
 
+    /**
+     * Obtains a {@link ResultSet} over a given ID query.
+     *
+     * <p>A test-only method.
+     */
     @VisibleForTesting
-    public ResultSet resultSet(Iterable<I> ids) {
+    protected ResultSet resultSet(Iterable<I> ids) {
         SelectMessagesInBulk<I, M> query = composeSelectMessagesInBulkQuery(ids);
         ResultSet resultSet = query.query()
                                    .getResults();
@@ -94,7 +104,7 @@ public abstract class MessageTable<I, M extends Message> extends AbstractTable<I
      *
      * <p>If a record with the same ID already exists, it is overwritten.
      */
-    public void write(M record) {
+    protected void write(M record) {
         write(idOf(record), record);
     }
 
@@ -104,7 +114,7 @@ public abstract class MessageTable<I, M extends Message> extends AbstractTable<I
      * <p>If some of the records have IDs that already exist, the respective records in the DB are
      * overwritten.
      */
-    public void writeAll(Iterable<M> records) {
+    protected void writeAll(Iterable<M> records) {
         Collection<I> existingIds = existingIds(records);
 
         Map<I, M> existingRecords = stream(records)
@@ -123,7 +133,7 @@ public abstract class MessageTable<I, M extends Message> extends AbstractTable<I
      *
      * <p>Non-existent records are ignored.
      */
-    public void removeAll(Iterable<M> records) {
+    protected void removeAll(Iterable<M> records) {
         List<I> ids = stream(records)
                 .map(this::idOf)
                 .collect(toList());

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/message/SelectMessagesInBulk.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/message/SelectMessagesInBulk.java
@@ -69,7 +69,7 @@ final class SelectMessagesInBulk<I, M extends Message>
         return iterator;
     }
 
-    private AbstractSQLQuery<Object, ?> query() {
+    AbstractSQLQuery<Object, ?> query() {
         List<Object> normalizedIds = ids
                 .stream()
                 .map(idColumn::normalize)

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/message/SelectSingleMessage.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/message/SelectSingleMessage.java
@@ -34,24 +34,24 @@ import static io.spine.server.storage.jdbc.message.MessageTable.bytesColumn;
  * @param <M>
  *         the message type
  */
-final class SelectSingleMessage<I, M extends Message> extends SelectMessageByIdQuery<I, M> {
+public final class SelectSingleMessage<I, M extends Message> extends SelectMessageByIdQuery<I, M> {
 
     private SelectSingleMessage(Builder<I, M> builder) {
         super(builder);
     }
 
     @Override
-    protected AbstractSQLQuery<Object, ?> query() {
+    public AbstractSQLQuery<Object, ?> query() {
         return factory().select(pathOf(bytesColumn()))
                         .from(table())
                         .where(idEquals());
     }
 
-    static <I, M extends Message> Builder<I, M> newBuilder() {
+    public static <I, M extends Message> Builder<I, M> newBuilder() {
         return new Builder<>();
     }
 
-    static class Builder<I, M extends Message>
+    public static class Builder<I, M extends Message>
             extends SelectMessageByIdQuery.Builder<Builder<I, M>, SelectSingleMessage<I, M>, I, M> {
 
         @Override

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/projection/LastHandledEventTimeTable.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/projection/LastHandledEventTimeTable.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.storage.jdbc.projection;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Timestamp;
 import io.spine.server.storage.jdbc.DataSourceWrapper;
@@ -53,6 +54,18 @@ class LastHandledEventTimeTable extends AbstractTable<String, Timestamp, Timesta
     @Override
     protected List<? extends TableColumn> tableColumns() {
         return ImmutableList.copyOf(Column.values());
+    }
+
+    @VisibleForTesting
+    @Override
+    public String name() {
+        return super.name();
+    }
+
+    @VisibleForTesting
+    @Override
+    public IdColumn<String> idColumn() {
+        return super.idColumn();
     }
 
     @Override

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/query/AbstractQuery.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/query/AbstractQuery.java
@@ -275,9 +275,10 @@ public abstract class AbstractQuery implements StorageQuery {
      * <p>{@linkplain Connection#commit() Commits} a transaction, that was successfully executed
      * or {@linkplain Connection#rollback() rollbacks} it otherwise.
      */
-    private static class TransactionHandler extends SQLBaseListener {
+    @VisibleForTesting
+    static class TransactionHandler extends SQLBaseListener {
 
-        private static final SQLListener INSTANCE = new TransactionHandler();
+        static final SQLListener INSTANCE = new TransactionHandler();
 
         @Override
         public void executed(SQLListenerContext context) {

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/query/AbstractTable.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/query/AbstractTable.java
@@ -20,7 +20,6 @@
 
 package io.spine.server.storage.jdbc.query;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -225,13 +224,11 @@ public abstract class AbstractTable<I, R, W> implements Logging {
         return ImmutableMap.of();
     }
 
-    @VisibleForTesting
-    public String name() {
+    protected String name() {
         return name;
     }
 
-    @VisibleForTesting
-    public IdColumn<I> idColumn() {
+    protected IdColumn<I> idColumn() {
         return idColumn;
     }
 

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/query/AbstractTable.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/query/AbstractTable.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.storage.jdbc.query;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -224,11 +225,13 @@ public abstract class AbstractTable<I, R, W> implements Logging {
         return ImmutableMap.of();
     }
 
-    protected String name() {
+    @VisibleForTesting
+    public String name() {
         return name;
     }
 
-    protected IdColumn<I> idColumn() {
+    @VisibleForTesting
+    public IdColumn<I> idColumn() {
         return idColumn;
     }
 

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/DataSourceWrapperTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/DataSourceWrapperTest.java
@@ -46,7 +46,7 @@ class DataSourceWrapperTest {
     }
 
     @Test
-    @DisplayName("provide database meta data")
+    @DisplayName("provide database metadata")
     void returnMetaData() {
         DataSourceWrapper dataSourceWrapper = whichIsStoredInMemory(newUuid());
         DataSourceMetaData metaData = dataSourceWrapper.metaData();
@@ -61,7 +61,7 @@ class DataSourceWrapperTest {
 
     @Test
     @MuteLogging
-    @DisplayName("throw `DatabaseException` if failed to obtain a meta data")
+    @DisplayName("throw `DatabaseException` if failed to obtain a metadata")
     void throwOnGetMetaDataError() {
         ThrowingHikariDataSource dataSource = whichIsThrowingByCommand(newUuid());
         DataSourceWrapper wrapper = DataSourceWrapper.wrap(dataSource);
@@ -71,7 +71,7 @@ class DataSourceWrapperTest {
     }
 
     @Test
-    @DisplayName("throw ISE if obtaining meta data when already closed")
+    @DisplayName("throw ISE if obtaining metadata when already closed")
     void throwIseIfAlreadyClosed() {
         DataSourceWrapper dataSource = whichIsStoredInMemory(newUuid());
         dataSource.close();

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/DataSourceWrapperTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/DataSourceWrapperTest.java
@@ -20,22 +20,24 @@
 
 package io.spine.server.storage.jdbc;
 
-import io.spine.server.storage.jdbc.GivenDataSource.ClosableDataSource;
+import io.spine.testing.logging.MuteLogging;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import javax.sql.DataSource;
+
+import static io.spine.base.Identifier.newUuid;
+import static io.spine.server.storage.jdbc.GivenDataSource.whichIsThrowingOnClose;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doThrow;
 
 @DisplayName("DataSourceWrapper should")
 class DataSourceWrapperTest {
 
     @Test
-    @DisplayName("throw DatabaseException if failing to close")
-    void throwIfFailToClose() throws Exception {
-        ClosableDataSource dataSource = GivenDataSource.whichIsAutoCloseable();
-        doThrow(new Exception("")).when(dataSource)
-                                  .close();
+    @MuteLogging
+    @DisplayName("throw `DatabaseException` if failing to close")
+    void throwIfFailToClose() {
+        DataSource dataSource = whichIsThrowingOnClose(newUuid());
         DataSourceWrapper wrapper = DataSourceWrapper.wrap(dataSource);
         assertThrows(DatabaseException.class, wrapper::close);
     }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/DataSourceWrapperTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/DataSourceWrapperTest.java
@@ -20,14 +20,13 @@
 
 package io.spine.server.storage.jdbc;
 
+import io.spine.server.storage.jdbc.GivenDataSource.ThrowingHikariDataSource;
 import io.spine.testing.logging.MuteLogging;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import javax.sql.DataSource;
-
 import static io.spine.base.Identifier.newUuid;
-import static io.spine.server.storage.jdbc.GivenDataSource.whichIsThrowingOnClose;
+import static io.spine.server.storage.jdbc.GivenDataSource.whichIsThrowingByCommand;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("DataSourceWrapper should")
@@ -37,7 +36,8 @@ class DataSourceWrapperTest {
     @MuteLogging
     @DisplayName("throw `DatabaseException` if failing to close")
     void throwIfFailToClose() {
-        DataSource dataSource = whichIsThrowingOnClose(newUuid());
+        ThrowingHikariDataSource dataSource = whichIsThrowingByCommand(newUuid());
+        dataSource.setThrowOnClose(true);
         DataSourceWrapper wrapper = DataSourceWrapper.wrap(dataSource);
         assertThrows(DatabaseException.class, wrapper::close);
     }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/DefaultDataSourceConfigConverterTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/DefaultDataSourceConfigConverterTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
 import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
 import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
-import static org.mockito.Mockito.mock;
 
 @DisplayName("DefaultDataSourceConfigConverter should")
 class DefaultDataSourceConfigConverterTest {
@@ -42,7 +41,13 @@ class DefaultDataSourceConfigConverterTest {
     @DisplayName(NOT_ACCEPT_NULLS)
     void passNullToleranceCheck() {
         NullPointerTester tester = new NullPointerTester();
-        tester.setDefault(DataSourceConfig.class, mock(DataSourceConfig.class));
+        DataSourceConfig dataSource = DataSourceConfig.newBuilder()
+                                                      .setDataSourceClassName("SomeClass")
+                                                      .setJdbcUrl("some:url")
+                                                      .setUsername("")
+                                                      .setPassword("")
+                                                      .build();
+        tester.setDefault(DataSourceConfig.class, dataSource);
         tester.testStaticMethods(DefaultDataSourceConfigConverter.class,
                                  NullPointerTester.Visibility.PACKAGE);
     }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/DefaultDataSourceConfigConverterTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/DefaultDataSourceConfigConverterTest.java
@@ -41,12 +41,13 @@ class DefaultDataSourceConfigConverterTest {
     @DisplayName(NOT_ACCEPT_NULLS)
     void passNullToleranceCheck() {
         NullPointerTester tester = new NullPointerTester();
-        DataSourceConfig dataSource = DataSourceConfig.newBuilder()
-                                                      .setDataSourceClassName("SomeClass")
-                                                      .setJdbcUrl("some:url")
-                                                      .setUsername("")
-                                                      .setPassword("")
-                                                      .build();
+        DataSourceConfig dataSource = DataSourceConfig
+                .newBuilder()
+                .setDataSourceClassName("SomeClass")
+                .setJdbcUrl("some:url")
+                .setUsername("")
+                .setPassword("")
+                .build();
         tester.setDefault(DataSourceConfig.class, dataSource);
         tester.testStaticMethods(DefaultDataSourceConfigConverter.class,
                                  NullPointerTester.Visibility.PACKAGE);

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/GivenDataSource.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/GivenDataSource.java
@@ -26,7 +26,6 @@ import com.zaxxer.hikari.HikariDataSource;
 import javax.sql.DataSource;
 
 import static io.spine.base.Identifier.newUuid;
-import static org.mockito.Mockito.mock;
 
 public class GivenDataSource {
 
@@ -37,11 +36,9 @@ public class GivenDataSource {
     // See the details: https://github.com/SpineEventEngine/jdbc-storage/issues/37
     private static final String HSQL_IN_MEMORY_DB_URL_PREFIX = "jdbc:h2:mem:";
 
-    private GivenDataSource() {
-    }
+    private static final String UNSUPPORTED = "Operation unsupported.";
 
-    public static DataSourceWrapper withoutSuperpowers() {
-        return mock(DataSourceWrapper.class);
+    private GivenDataSource() {
     }
 
     public static DataSourceWrapper whichIsStoredInMemory(String dbName) {
@@ -75,25 +72,11 @@ public class GivenDataSource {
         return HSQL_IN_MEMORY_DB_URL_PREFIX + dbNamePrefix + newUuid();
     }
 
-    private static class ThrowingDataSource extends HikariDataSource {
-
-        private ThrowingDataSource(HikariConfig configuration) {
-            super(configuration);
-        }
-
-        @Override
-        public void close() {
-            throw new IllegalStateException("Ignore this error.");
-        }
-    }
-
     /**
      * A test data source whose only purpose is to return a given data source
      * {@linkplain DataSourceWrapper#metaData() meta data}.
      */
     private static class DataSourceWithMetaData implements DataSourceWrapper {
-
-        private static final String UNSUPPORTED = "Operation unsupported.";
 
         private final String productName;
         private final int majorVersion;
@@ -133,6 +116,23 @@ public class GivenDataSource {
         @Override
         public void close() throws DatabaseException {
             throw new IllegalStateException(UNSUPPORTED);
+        }
+
+        @Override
+        public boolean isClosed() {
+            return false;
+        }
+    }
+
+    private static class ThrowingDataSource extends HikariDataSource {
+
+        private ThrowingDataSource(HikariConfig configuration) {
+            super(configuration);
+        }
+
+        @Override
+        public void close() {
+            throw new IllegalStateException("Ignore this error.");
         }
     }
 }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/GivenDataSource.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/GivenDataSource.java
@@ -75,7 +75,7 @@ public class GivenDataSource {
 
     /**
      * A test data source whose only purpose is to return a given data source
-     * {@linkplain DataSourceWrapper#metaData() meta data}.
+     * {@linkplain DataSourceWrapper#metaData() metadata}.
      */
     private static class DataSourceWithMetaData implements DataSourceWrapper {
 

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/JdbcStorageFactoryTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/JdbcStorageFactoryTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.base.Identifier.newUuid;
-import static io.spine.server.storage.jdbc.GivenDataSource.whichIsHoldingMetadata;
+import static io.spine.server.storage.jdbc.GivenDataSource.whichHoldsMetadata;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
 import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
 import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
@@ -155,7 +155,7 @@ class JdbcStorageFactoryTest {
     @Test
     @DisplayName("select mapping based on the given data source")
     void useMySqlMappingByDefault() {
-        DataSourceWrapper dataSource = whichIsHoldingMetadata(
+        DataSourceWrapper dataSource = whichHoldsMetadata(
                 MYSQL_5_7.getDatabaseProductName(),
                 MYSQL_5_7.getMajorVersion(),
                 MYSQL_5_7.getMinorVersion());

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/JdbcStorageFactoryTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/JdbcStorageFactoryTest.java
@@ -154,7 +154,7 @@ class JdbcStorageFactoryTest {
 
     @Test
     @DisplayName("select mapping based on the given data source")
-    void useMySqlMappingByDefault() {
+    void selectMapping() {
         DataSourceWrapper dataSource = whichHoldsMetadata(
                 MYSQL_5_7.getDatabaseProductName(),
                 MYSQL_5_7.getMajorVersion(),

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/PredefinedMappingTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/PredefinedMappingTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.spine.server.storage.jdbc.GivenDataSource.whichIsHoldingMetadata;
+import static io.spine.server.storage.jdbc.GivenDataSource.whichHoldsMetadata;
 import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
 import static io.spine.server.storage.jdbc.PredefinedMapping.POSTGRESQL_10_1;
 import static io.spine.server.storage.jdbc.PredefinedMapping.select;
@@ -46,9 +46,9 @@ class PredefinedMappingTest {
     @Test
     @DisplayName("be selected by database product name and major version")
     void selectTypeMapping() {
-        DataSourceWrapper dataSource = whichIsHoldingMetadata(mapping.getDatabaseProductName(),
-                                                              mapping.getMajorVersion(),
-                                                              mapping.getMinorVersion());
+        DataSourceWrapper dataSource = whichHoldsMetadata(mapping.getDatabaseProductName(),
+                                                          mapping.getMajorVersion(),
+                                                          mapping.getMinorVersion());
         assertThat(select(dataSource)).isEqualTo(mapping);
     }
 
@@ -56,9 +56,9 @@ class PredefinedMappingTest {
     @DisplayName("not be selected if major versions are different")
     void notSelectForDifferentVersion() {
         int newMajorVersion = mapping.getMajorVersion() + 1;
-        DataSourceWrapper dataSource = whichIsHoldingMetadata(mapping.getDatabaseProductName(),
-                                                              newMajorVersion,
-                                                              mapping.getMinorVersion());
+        DataSourceWrapper dataSource = whichHoldsMetadata(mapping.getDatabaseProductName(),
+                                                          newMajorVersion,
+                                                          mapping.getMinorVersion());
         assertThat(select(dataSource)).isNotEqualTo(mapping);
     }
 }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/PredefinedMappingTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/PredefinedMappingTest.java
@@ -23,21 +23,13 @@ package io.spine.server.storage.jdbc;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.SQLException;
-
+import static com.google.common.truth.Truth.assertThat;
+import static io.spine.server.storage.jdbc.GivenDataSource.whichIsHoldingMetadata;
 import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
 import static io.spine.server.storage.jdbc.PredefinedMapping.POSTGRESQL_10_1;
 import static io.spine.server.storage.jdbc.PredefinedMapping.select;
 import static io.spine.testing.Tests.nullRef;
-import static io.spine.util.Exceptions.illegalStateWithCauseOf;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 
 @DisplayName("PredefinedMapping should")
 class PredefinedMappingTest {
@@ -54,46 +46,19 @@ class PredefinedMappingTest {
     @Test
     @DisplayName("be selected by database product name and major version")
     void selectTypeMapping() {
-        DataSourceWrapper dataSource = dataSourceMock(mapping.getDatabaseProductName(),
-                                                      mapping.getMajorVersion(),
-                                                      mapping.getMinorVersion());
-        assertEquals(mapping, select(dataSource));
+        DataSourceWrapper dataSource = whichIsHoldingMetadata(mapping.getDatabaseProductName(),
+                                                              mapping.getMajorVersion(),
+                                                              mapping.getMinorVersion());
+        assertThat(select(dataSource)).isEqualTo(mapping);
     }
 
     @Test
     @DisplayName("not be selected if major versions are different")
     void notSelectForDifferentVersion() {
-        String databaseProductName = mapping.getDatabaseProductName();
-        int differentVersion = mapping.getMajorVersion() + 1;
-        DataSourceWrapper dataSource = dataSourceMock(databaseProductName,
-                                                      differentVersion,
-                                                      differentVersion);
-        assertNotEquals(mapping, select(dataSource));
-    }
-
-    private static DataSourceWrapper dataSourceMock(String databaseProductName,
-                                                    int majorVersion,
-                                                    int minorVersion) {
-        DataSourceWrapper dataSource = mock(DataSourceWrapper.class);
-        ConnectionWrapper connectionWrapper = mock(ConnectionWrapper.class);
-        Connection connection = mock(Connection.class);
-        DatabaseMetaData metadata = mock(DatabaseMetaData.class);
-        doReturn(connectionWrapper).when(dataSource)
-                                   .getConnection(anyBoolean());
-        doReturn(connection).when(connectionWrapper)
-                            .get();
-        try {
-            doReturn(metadata).when(connection)
-                              .getMetaData();
-            doReturn(databaseProductName).when(metadata)
-                                         .getDatabaseProductName();
-            doReturn(majorVersion).when(metadata)
-                                  .getDatabaseMajorVersion();
-            doReturn(minorVersion).when(metadata)
-                                  .getDatabaseMinorVersion();
-            return dataSource;
-        } catch (SQLException e) {
-            throw illegalStateWithCauseOf(e);
-        }
+        int newMajorVersion = mapping.getMajorVersion() + 1;
+        DataSourceWrapper dataSource = whichIsHoldingMetadata(mapping.getDatabaseProductName(),
+                                                              newMajorVersion,
+                                                              mapping.getMinorVersion());
+        assertThat(select(dataSource)).isNotEqualTo(mapping);
     }
 }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/PredefinedMappingTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/PredefinedMappingTest.java
@@ -49,7 +49,8 @@ class PredefinedMappingTest {
         DataSourceWrapper dataSource = whichHoldsMetadata(mapping.getDatabaseProductName(),
                                                           mapping.getMajorVersion(),
                                                           mapping.getMinorVersion());
-        assertThat(select(dataSource)).isEqualTo(mapping);
+        assertThat(select(dataSource))
+                .isEqualTo(mapping);
     }
 
     @Test
@@ -59,6 +60,7 @@ class PredefinedMappingTest {
         DataSourceWrapper dataSource = whichHoldsMetadata(mapping.getDatabaseProductName(),
                                                           newMajorVersion,
                                                           mapping.getMinorVersion());
-        assertThat(select(dataSource)).isNotEqualTo(mapping);
+        assertThat(select(dataSource))
+                .isNotEqualTo(mapping);
     }
 }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/AggregateEventRecordTableTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/AggregateEventRecordTableTest.java
@@ -32,8 +32,7 @@ import static io.spine.base.Identifier.newUuid;
 import static io.spine.base.Time.currentTime;
 import static io.spine.core.Versions.newVersion;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
-import static io.spine.server.storage.jdbc.GivenDataSource.withoutSuperpowers;
-import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
 import static io.spine.server.storage.jdbc.aggregate.AggregateEventRecordTable.Column.KIND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -45,7 +44,9 @@ class AggregateEventRecordTableTest {
     @DisplayName("throw ISE on attempt to update event record")
     void throwOnEventRecordUpdate() {
         AggregateEventRecordTable<String> table =
-                new AggregateEventRecordTable<>(AnAggregate.class, withoutSuperpowers(), MYSQL_5_7);
+                new AggregateEventRecordTable<>(AnAggregate.class,
+                                                whichIsStoredInMemory(newUuid()),
+                                                H2_1_4);
         assertThrows(IllegalStateException.class,
                      () -> table.update(newUuid(), AggregateEventRecord.getDefaultInstance()));
     }
@@ -55,7 +56,7 @@ class AggregateEventRecordTableTest {
     void storeRecordKind() {
         DataSourceWrapper dataSource = whichIsStoredInMemory(newUuid());
         AggregateEventRecordTable<String> table =
-                new AggregateEventRecordTable<>(AnAggregate.class, dataSource, MYSQL_5_7);
+                new AggregateEventRecordTable<>(AnAggregate.class, dataSource, H2_1_4);
         table.create();
 
         Snapshot snapshot = Snapshot.newBuilder()

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorageTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorageTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 import java.sql.SQLException;
 
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
-import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
 import static io.spine.testing.Tests.nullRef;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -116,7 +116,7 @@ class JdbcAggregateStorageTest extends AggregateStorageTest {
         JdbcAggregateStorage<I> storage = builder.setMultitenant(false)
                                                  .setDataSource(dataSource)
                                                  .setAggregateClass(aggregateClass)
-                                                 .setTypeMapping(MYSQL_5_7)
+                                                 .setTypeMapping(H2_1_4)
                                                  .build();
         return storage;
     }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorageVisibilityHandlingTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorageVisibilityHandlingTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -52,7 +52,7 @@ class JdbcAggregateStorageVisibilityHandlingTest
                         .setMultitenant(false)
                         .setAggregateClass(TestAggregate.class)
                         .setDataSource(dataSource)
-                        .setTypeMapping(MYSQL_5_7)
+                        .setTypeMapping(H2_1_4)
                         .build();
         return storage;
     }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcInboxStorageTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcInboxStorageTest.java
@@ -44,7 +44,7 @@ import java.util.Optional;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.spine.server.delivery.InboxMessageStatus.TO_DELIVER;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
-import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
 import static io.spine.server.storage.jdbc.delivery.given.TestInboxMessage.generateMultiple;
 import static io.spine.server.storage.jdbc.delivery.given.TestShardIndex.newIndex;
 import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
@@ -65,7 +65,7 @@ class JdbcInboxStorageTest extends InboxStorageTest {
                 .newBuilder()
                 .setDataSource(dataSource)
                 .setMultitenant(false)
-                .setTypeMapping(MYSQL_5_7)
+                .setTypeMapping(H2_1_4)
                 .build();
         super.setUp();
     }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcShardedWorkRegistryTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcShardedWorkRegistryTest.java
@@ -40,7 +40,7 @@ import java.util.Optional;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
-import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
 import static io.spine.server.storage.jdbc.delivery.given.TestShardIndex.newIndex;
 import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
 import static org.junit.Assert.assertFalse;
@@ -61,7 +61,7 @@ class JdbcShardedWorkRegistryTest extends ShardedWorkRegistryTest {
         registry = JdbcShardedWorkRegistry
                 .newBuilder()
                 .setDataSource(dataSource)
-                .setTypeMapping(MYSQL_5_7)
+                .setTypeMapping(H2_1_4)
                 .build();
     }
 

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/query/SelectMessageId.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/query/SelectMessageId.java
@@ -18,12 +18,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.server.storage.jdbc.given.table;
+package io.spine.server.storage.jdbc.given.query;
 
 import com.google.protobuf.Message;
 import com.querydsl.sql.AbstractSQLQuery;
 import io.spine.server.storage.jdbc.message.MessageTable;
 import io.spine.server.storage.jdbc.query.IdAwareQuery;
+
+import java.sql.ResultSet;
 
 /**
  * A test query for selecting a {@code Message} ID from the {@link MessageTable}.
@@ -31,28 +33,35 @@ import io.spine.server.storage.jdbc.query.IdAwareQuery;
  * <p>Although selecting a message ID by ID is hardly a viable case in real life, it's sometimes
  * necessary in tests.
  *
+ * <p>The query result is returned as a {@link ResultSet}.
+ *
  * @param <I>
  *         the ID type
  * @param <M>
  *         the message type
  */
-final class SelectMessageId<I, M extends Message> extends IdAwareQuery<I> {
+public final class SelectMessageId<I, M extends Message> extends IdAwareQuery<I> {
 
     private SelectMessageId(Builder<I, M> builder) {
         super(builder);
     }
 
-    AbstractSQLQuery<Object, ?> query() {
+    public ResultSet getResults() {
+        ResultSet results = query().getResults();
+        return results;
+    }
+
+    private AbstractSQLQuery<Object, ?> query() {
         return factory().select(pathOf(idColumn().column()))
                         .from(table())
                         .where(idEquals());
     }
 
-    static <I, M extends Message> Builder<I, M> newBuilder() {
+    public static <I, M extends Message> Builder<I, M> newBuilder() {
         return new Builder<>();
     }
 
-    static class Builder<I, M extends Message>
+    public static class Builder<I, M extends Message>
             extends IdAwareQuery.Builder<I, Builder<I, M>, SelectMessageId<I, M>> {
 
         @Override

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/query/SelectTimestampById.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/query/SelectTimestampById.java
@@ -24,6 +24,8 @@ import com.google.protobuf.Timestamp;
 import com.querydsl.sql.AbstractSQLQuery;
 import io.spine.server.storage.jdbc.query.SelectMessageByIdQuery;
 
+import java.sql.ResultSet;
+
 import static io.spine.server.storage.jdbc.message.MessageTable.bytesColumn;
 
 /**
@@ -37,6 +39,11 @@ public class SelectTimestampById<I> extends SelectMessageByIdQuery<I, Timestamp>
 
     private SelectTimestampById(Builder<I> builder) {
         super(builder);
+    }
+
+    public ResultSet getResults() {
+        ResultSet results = query().getResults();
+        return results;
     }
 
     @Override

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/query/SelectTimestampById.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/query/SelectTimestampById.java
@@ -18,51 +18,53 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.server.storage.jdbc.message;
+package io.spine.server.storage.jdbc.given.query;
 
-import com.google.protobuf.Message;
+import com.google.protobuf.Timestamp;
 import com.querydsl.sql.AbstractSQLQuery;
 import io.spine.server.storage.jdbc.query.SelectMessageByIdQuery;
 
 import static io.spine.server.storage.jdbc.message.MessageTable.bytesColumn;
 
 /**
- * Selects a single message from the {@link MessageTable} by its ID.
+ * Selects a {@link Timestamp} by ID from the
+ * {@linkplain io.spine.server.storage.jdbc.message.MessageTable message table}.
  *
  * @param <I>
- *         the ID type
- * @param <M>
- *         the message type
+ *         the type of IDs
  */
-final class SelectSingleMessage<I, M extends Message> extends SelectMessageByIdQuery<I, M> {
+public class SelectTimestampById<I> extends SelectMessageByIdQuery<I, Timestamp> {
 
-    private SelectSingleMessage(Builder<I, M> builder) {
+    private SelectTimestampById(Builder<I> builder) {
         super(builder);
     }
 
     @Override
-    protected AbstractSQLQuery<Object, ?> query() {
+    public AbstractSQLQuery<Object, ?> query() {
         return factory().select(pathOf(bytesColumn()))
                         .from(table())
                         .where(idEquals());
     }
 
-    static <I, M extends Message> Builder<I, M> newBuilder() {
+    public static <I> Builder<I> newBuilder() {
         return new Builder<>();
     }
 
-    static class Builder<I, M extends Message>
-            extends SelectMessageByIdQuery.Builder<Builder<I, M>, SelectSingleMessage<I, M>, I, M> {
+    public static class Builder<I>
+            extends SelectMessageByIdQuery.Builder<Builder<I>,
+                                                   SelectTimestampById<I>,
+                                                   I,
+                                                   Timestamp> {
 
         @Override
-        protected Builder<I, M> getThis() {
+        protected Builder<I> getThis() {
             return this;
         }
 
         @Override
-        protected SelectSingleMessage<I, M> doBuild() {
+        protected SelectTimestampById<I> doBuild() {
             setMessageColumnName(bytesColumn().name());
-            return new SelectSingleMessage<>(this);
+            return new SelectTimestampById<>(this);
         }
     }
 }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/query/package-info.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/query/package-info.java
@@ -19,12 +19,12 @@
  */
 
 /**
- * This package contains sample SQL tables that can be filled with data and then queried.
+ * This package contains sample SQL queries for storage tables.
  */
 
 @CheckReturnValue
 @ParametersAreNonnullByDefault
-package io.spine.server.storage.jdbc.given.table;
+package io.spine.server.storage.jdbc.given.query;
 
 import com.google.errorprone.annotations.CheckReturnValue;
 

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/SelectMessageId.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/SelectMessageId.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.jdbc.given.table;
+
+import com.google.protobuf.Message;
+import com.querydsl.sql.AbstractSQLQuery;
+import io.spine.server.storage.jdbc.message.MessageTable;
+import io.spine.server.storage.jdbc.query.IdAwareQuery;
+
+/**
+ * A test query for selecting a {@code Message} ID from the {@link MessageTable}.
+ *
+ * <p>Although selecting a message ID by ID is hardly a viable case in real life, it's sometimes
+ * necessary in tests.
+ *
+ * @param <I>
+ *         the ID type
+ * @param <M>
+ *         the message type
+ */
+final class SelectMessageId<I, M extends Message> extends IdAwareQuery<I> {
+
+    private SelectMessageId(Builder<I, M> builder) {
+        super(builder);
+    }
+
+    AbstractSQLQuery<Object, ?> query() {
+        return factory().select(pathOf(idColumn().column()))
+                        .from(table())
+                        .where(idEquals());
+    }
+
+    static <I, M extends Message> Builder<I, M> newBuilder() {
+        return new Builder<>();
+    }
+
+    static class Builder<I, M extends Message>
+            extends IdAwareQuery.Builder<I, Builder<I, M>, SelectMessageId<I, M>> {
+
+        @Override
+        protected Builder<I, M> getThis() {
+            return this;
+        }
+
+        @Override
+        protected SelectMessageId<I, M> doBuild() {
+            return new SelectMessageId<>(this);
+        }
+    }
+}

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampByLong.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampByLong.java
@@ -20,96 +20,42 @@
 
 package io.spine.server.storage.jdbc.given.table;
 
-import com.google.common.collect.ImmutableList;
-import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Timestamp;
 import io.spine.server.storage.jdbc.DataSourceWrapper;
 import io.spine.server.storage.jdbc.Type;
 import io.spine.server.storage.jdbc.TypeMapping;
-import io.spine.server.storage.jdbc.given.query.SelectMessageId;
 import io.spine.server.storage.jdbc.message.MessageTable;
 import io.spine.server.storage.jdbc.query.IdColumn;
 
-import java.sql.ResultSet;
-
-import static io.spine.server.storage.jdbc.Type.INT;
 import static io.spine.server.storage.jdbc.Type.LONG;
 
 /**
  * Holds {@link Timestamp} records by {@code Long} IDs.
  */
-public final class TimestampByLong extends MessageTable<Long, Timestamp> {
+public final class TimestampByLong extends TimestampTable<Long> {
 
     private static final String NAME = "timestamp_by_long";
 
     public TimestampByLong(DataSourceWrapper dataSource, TypeMapping typeMapping) {
-        super(NAME, IdColumn.of(Column.ID), dataSource, typeMapping);
+        super(NAME, IdColumn.of(TheIdColumn.INSTANCE), dataSource, typeMapping);
     }
 
-    @Override
-    public void write(Timestamp record) {
-        super.write(record);
-    }
-
-    /**
-     * Reads a given ID back from the database as a {@link ResultSet}.
-     *
-     * <p>Allows to obtain a {@link ResultSet} with a message ID which is sometimes necessary in
-     * tests.
-     */
-    public ResultSet resultSetWithId(Long id) {
-        SelectMessageId.Builder<Long, Timestamp> queryBuilder = SelectMessageId
-                .<Long, Timestamp>newBuilder()
-                .setDataSource(dataSource())
-                .setTableName(name())
-                .setIdColumn(idColumn())
-                .setId(id);
-        SelectMessageId<Long, Timestamp> query = queryBuilder.build();
-        ResultSet resultSet = query.getResults();
-        return resultSet;
-    }
-
-    @Override
-    public Long idOf(Timestamp record) {
-        return super.idOf(record);
-    }
-
-    @Override
-    protected Descriptor messageDescriptor() {
-        return Timestamp.getDescriptor();
-    }
-
-    @Override
-    protected Iterable<Column> messageSpecificColumns() {
-        return ImmutableList.copyOf(Column.values());
-    }
-
-    enum Column implements MessageTable.Column<Timestamp> {
-        ID(LONG, Column::idOf),
-        SECONDS(LONG, Timestamp::getSeconds),
-        NANOS(INT, Timestamp::getNanos);
-
-        private final Type type;
-        private final Getter<Timestamp> getter;
-
-        Column(Type type, Getter<Timestamp> getter) {
-            this.type = type;
-            this.getter = getter;
-        }
+    public enum TheIdColumn implements MessageTable.Column<Timestamp> {
+        INSTANCE;
 
         @Override
         public Getter<Timestamp> getter() {
-            return getter;
+            return TheIdColumn::idOf;
         }
 
         @Override
         public Type type() {
-            return type;
+            return LONG;
         }
 
         @Override
         public boolean isPrimaryKey() {
-            return this == ID;
+            return true;
         }
 
         @Override
@@ -117,9 +63,9 @@ public final class TimestampByLong extends MessageTable<Long, Timestamp> {
             return false;
         }
 
-        private static long idOf(Timestamp timestamp) {
-            long id = timestamp.getSeconds() + timestamp.getNanos();
-            return id;
+        private static Long idOf(Timestamp timestamp) {
+            long result = timestamp.getSeconds() + timestamp.getNanos();
+            return result;
         }
     }
 }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampByLong.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampByLong.java
@@ -26,6 +26,7 @@ import com.google.protobuf.Timestamp;
 import io.spine.server.storage.jdbc.DataSourceWrapper;
 import io.spine.server.storage.jdbc.Type;
 import io.spine.server.storage.jdbc.TypeMapping;
+import io.spine.server.storage.jdbc.given.query.SelectMessageId;
 import io.spine.server.storage.jdbc.message.MessageTable;
 import io.spine.server.storage.jdbc.query.IdColumn;
 
@@ -45,6 +46,11 @@ public final class TimestampByLong extends MessageTable<Long, Timestamp> {
         super(NAME, IdColumn.of(Column.ID), dataSource, typeMapping);
     }
 
+    @Override
+    public void write(Timestamp record) {
+        super.write(record);
+    }
+
     /**
      * Reads a given ID back from the database as a {@link ResultSet}.
      *
@@ -59,8 +65,7 @@ public final class TimestampByLong extends MessageTable<Long, Timestamp> {
                 .setIdColumn(idColumn())
                 .setId(id);
         SelectMessageId<Long, Timestamp> query = queryBuilder.build();
-        ResultSet resultSet = query.query()
-                                   .getResults();
+        ResultSet resultSet = query.getResults();
         return resultSet;
     }
 

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampByLong.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampByLong.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.jdbc.given.table;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Timestamp;
+import io.spine.server.storage.jdbc.DataSourceWrapper;
+import io.spine.server.storage.jdbc.Type;
+import io.spine.server.storage.jdbc.TypeMapping;
+import io.spine.server.storage.jdbc.message.MessageTable;
+import io.spine.server.storage.jdbc.query.IdColumn;
+
+import java.sql.ResultSet;
+
+import static io.spine.server.storage.jdbc.Type.INT;
+import static io.spine.server.storage.jdbc.Type.LONG;
+
+/**
+ * Holds {@link Timestamp} records by {@code Long} IDs.
+ */
+public final class TimestampByLong extends MessageTable<Long, Timestamp> {
+
+    private static final String NAME = "timestamp_by_long";
+
+    public TimestampByLong(DataSourceWrapper dataSource, TypeMapping typeMapping) {
+        super(NAME, IdColumn.of(Column.ID), dataSource, typeMapping);
+    }
+
+    /**
+     * Reads a given ID back from the database as a {@link ResultSet}.
+     *
+     * <p>Allows to obtain a {@link ResultSet} with a message ID which is sometimes necessary in
+     * tests.
+     */
+    public ResultSet resultSetWithId(Long id) {
+        SelectMessageId.Builder<Long, Timestamp> queryBuilder = SelectMessageId
+                .<Long, Timestamp>newBuilder()
+                .setDataSource(dataSource())
+                .setTableName(name())
+                .setIdColumn(idColumn())
+                .setId(id);
+        SelectMessageId<Long, Timestamp> query = queryBuilder.build();
+        ResultSet resultSet = query.query()
+                                   .getResults();
+        return resultSet;
+    }
+
+    @Override
+    public Long idOf(Timestamp record) {
+        return super.idOf(record);
+    }
+
+    @Override
+    protected Descriptor messageDescriptor() {
+        return Timestamp.getDescriptor();
+    }
+
+    @Override
+    protected Iterable<Column> messageSpecificColumns() {
+        return ImmutableList.copyOf(Column.values());
+    }
+
+    enum Column implements MessageTable.Column<Timestamp> {
+        ID(LONG, Column::idOf),
+        SECONDS(LONG, Timestamp::getSeconds),
+        NANOS(INT, Timestamp::getNanos);
+
+        private final Type type;
+        private final Getter<Timestamp> getter;
+
+        Column(Type type, Getter<Timestamp> getter) {
+            this.type = type;
+            this.getter = getter;
+        }
+
+        @Override
+        public Getter<Timestamp> getter() {
+            return getter;
+        }
+
+        @Override
+        public Type type() {
+            return type;
+        }
+
+        @Override
+        public boolean isPrimaryKey() {
+            return this == ID;
+        }
+
+        @Override
+        public boolean isNullable() {
+            return false;
+        }
+
+        private static long idOf(Timestamp timestamp) {
+            long id = timestamp.getSeconds() + timestamp.getNanos();
+            return id;
+        }
+    }
+}

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampByMessage.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampByMessage.java
@@ -28,6 +28,7 @@ import com.google.protobuf.util.Timestamps;
 import io.spine.server.storage.jdbc.DataSourceWrapper;
 import io.spine.server.storage.jdbc.Type;
 import io.spine.server.storage.jdbc.TypeMapping;
+import io.spine.server.storage.jdbc.given.query.SelectMessageId;
 import io.spine.server.storage.jdbc.message.MessageTable;
 import io.spine.server.storage.jdbc.query.IdColumn;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -48,6 +49,21 @@ public final class TimestampByMessage extends MessageTable<StringValue, Timestam
         super(NAME, IdColumn.of(Column.ID, StringValue.class), dataSource, typeMapping);
     }
 
+    @Override
+    public void write(Timestamp record) {
+        super.write(record);
+    }
+
+    @Override
+    public ResultSet resultSet(StringValue id) {
+        return super.resultSet(id);
+    }
+
+    @Override
+    public ResultSet resultSet(Iterable<StringValue> ids) {
+        return super.resultSet(ids);
+    }
+
     /**
      * Reads a given ID back from the database as a {@link ResultSet}.
      *
@@ -62,8 +78,7 @@ public final class TimestampByMessage extends MessageTable<StringValue, Timestam
                 .setIdColumn(idColumn())
                 .setId(id);
         SelectMessageId<StringValue, Timestamp> query = queryBuilder.build();
-        ResultSet resultSet = query.query()
-                                   .getResults();
+        ResultSet resultSet = query.getResults();
         return resultSet;
     }
 

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampByMessage.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampByMessage.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.jdbc.given.table;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
+import io.spine.server.storage.jdbc.DataSourceWrapper;
+import io.spine.server.storage.jdbc.Type;
+import io.spine.server.storage.jdbc.TypeMapping;
+import io.spine.server.storage.jdbc.message.MessageTable;
+import io.spine.server.storage.jdbc.query.IdColumn;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.sql.ResultSet;
+
+import static io.spine.server.storage.jdbc.Type.INT;
+import static io.spine.server.storage.jdbc.Type.LONG;
+
+/**
+ * Holds {@link Timestamp} records by {@code StringValue} IDs.
+ */
+public final class TimestampByMessage extends MessageTable<StringValue, Timestamp> {
+
+    private static final String NAME = "timestamp_by_message";
+
+    public TimestampByMessage(DataSourceWrapper dataSource, TypeMapping typeMapping) {
+        super(NAME, IdColumn.of(Column.ID, StringValue.class), dataSource, typeMapping);
+    }
+
+    /**
+     * Reads a given ID back from the database as a {@link ResultSet}.
+     *
+     * <p>Allows to obtain a {@link ResultSet} with a message ID which is sometimes necessary in
+     * tests.
+     */
+    public ResultSet resultSetWithId(StringValue id) {
+        SelectMessageId.Builder<StringValue, Timestamp> queryBuilder = SelectMessageId
+                .<StringValue, Timestamp>newBuilder()
+                .setDataSource(dataSource())
+                .setTableName(name())
+                .setIdColumn(idColumn())
+                .setId(id);
+        SelectMessageId<StringValue, Timestamp> query = queryBuilder.build();
+        ResultSet resultSet = query.query()
+                                   .getResults();
+        return resultSet;
+    }
+
+    @Override
+    public StringValue idOf(Timestamp record) {
+        return super.idOf(record);
+    }
+
+    @Override
+    protected Descriptor messageDescriptor() {
+        return Timestamp.getDescriptor();
+    }
+
+    @Override
+    protected Iterable<Column> messageSpecificColumns() {
+        return ImmutableList.copyOf(Column.values());
+    }
+
+    enum Column implements MessageTable.Column<Timestamp> {
+        ID(Column::idOf),
+        SECONDS(LONG, Timestamp::getSeconds),
+        NANOS(INT, Timestamp::getNanos);
+
+        private final @Nullable Type type;
+        private final Getter<Timestamp> getter;
+
+        Column(@Nullable Type type, Getter<Timestamp> getter) {
+            this.type = type;
+            this.getter = getter;
+        }
+
+        Column(Getter<Timestamp> getter) {
+            this(null, getter);
+        }
+
+        @Override
+        public Getter<Timestamp> getter() {
+            return getter;
+        }
+
+        @Override
+        public @Nullable Type type() {
+            return type;
+        }
+
+        @Override
+        public boolean isPrimaryKey() {
+            return this == ID;
+        }
+
+        @Override
+        public boolean isNullable() {
+            return false;
+        }
+
+        private static StringValue idOf(Timestamp timestamp) {
+            String value = Timestamps.toString(timestamp);
+            StringValue id = StringValue
+                    .newBuilder()
+                    .setValue(value)
+                    .build();
+            return id;
+        }
+    }
+}

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampByString.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampByString.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.jdbc.given.table;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
+import io.spine.server.storage.jdbc.DataSourceWrapper;
+import io.spine.server.storage.jdbc.Type;
+import io.spine.server.storage.jdbc.TypeMapping;
+import io.spine.server.storage.jdbc.message.MessageTable;
+import io.spine.server.storage.jdbc.query.IdColumn;
+
+import java.sql.ResultSet;
+
+import static io.spine.server.storage.jdbc.Type.INT;
+import static io.spine.server.storage.jdbc.Type.LONG;
+import static io.spine.server.storage.jdbc.Type.STRING_255;
+
+/**
+ * Holds {@link Timestamp} records by {@code String} IDs.
+ */
+public final class TimestampByString extends MessageTable<String, Timestamp> {
+
+    private static final String NAME = "timestamp_by_string";
+
+    public TimestampByString(DataSourceWrapper dataSource, TypeMapping typeMapping) {
+        super(NAME, IdColumn.of(Column.ID), dataSource, typeMapping);
+    }
+
+    /**
+     * Reads a given ID back from the database as a {@link ResultSet}.
+     *
+     * <p>Allows to obtain a {@link ResultSet} with a message ID which is sometimes necessary in
+     * tests.
+     */
+    public ResultSet resultSetWithId(String id) {
+        SelectMessageId.Builder<String, Timestamp> queryBuilder = SelectMessageId
+                .<String, Timestamp>newBuilder()
+                .setDataSource(dataSource())
+                .setTableName(name())
+                .setIdColumn(idColumn())
+                .setId(id);
+        SelectMessageId<String, Timestamp> query = queryBuilder.build();
+        ResultSet resultSet = query.query()
+                                   .getResults();
+        return resultSet;
+    }
+
+    @Override
+    public String idOf(Timestamp record) {
+        return super.idOf(record);
+    }
+
+    @Override
+    protected Descriptor messageDescriptor() {
+        return Timestamp.getDescriptor();
+    }
+
+    @Override
+    protected Iterable<Column> messageSpecificColumns() {
+        return ImmutableList.copyOf(Column.values());
+    }
+
+    enum Column implements MessageTable.Column<Timestamp> {
+        ID(STRING_255, Timestamps::toString),
+        SECONDS(LONG, Timestamp::getSeconds),
+        NANOS(INT, Timestamp::getNanos);
+
+        private final Type type;
+        private final Getter<Timestamp> getter;
+
+        Column(Type type, Getter<Timestamp> getter) {
+            this.type = type;
+            this.getter = getter;
+        }
+
+        @Override
+        public Getter<Timestamp> getter() {
+            return getter;
+        }
+
+        @Override
+        public Type type() {
+            return type;
+        }
+
+        @Override
+        public boolean isPrimaryKey() {
+            return this == ID;
+        }
+
+        @Override
+        public boolean isNullable() {
+            return false;
+        }
+    }
+}

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampByString.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampByString.java
@@ -28,6 +28,7 @@ import io.spine.server.storage.jdbc.DataSourceWrapper;
 import io.spine.server.storage.jdbc.Type;
 import io.spine.server.storage.jdbc.TypeMapping;
 import io.spine.server.storage.jdbc.message.MessageTable;
+import io.spine.server.storage.jdbc.message.SelectSingleMessage;
 import io.spine.server.storage.jdbc.query.IdColumn;
 
 import java.sql.ResultSet;
@@ -64,6 +65,11 @@ public final class TimestampByString extends MessageTable<String, Timestamp> {
         ResultSet resultSet = query.query()
                                    .getResults();
         return resultSet;
+    }
+
+    @Override
+    public SelectSingleMessage<String, Timestamp> composeSelectQuery(String id) {
+        return super.composeSelectQuery(id);
     }
 
     @Override

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampByString.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampByString.java
@@ -20,122 +20,43 @@
 
 package io.spine.server.storage.jdbc.given.table;
 
-import com.google.common.collect.ImmutableList;
-import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
 import io.spine.server.storage.jdbc.DataSourceWrapper;
 import io.spine.server.storage.jdbc.Type;
 import io.spine.server.storage.jdbc.TypeMapping;
-import io.spine.server.storage.jdbc.given.query.SelectMessageId;
-import io.spine.server.storage.jdbc.given.query.SelectTimestampById;
 import io.spine.server.storage.jdbc.message.MessageTable;
 import io.spine.server.storage.jdbc.query.IdColumn;
 
-import java.sql.ResultSet;
-
-import static io.spine.server.storage.jdbc.Type.INT;
-import static io.spine.server.storage.jdbc.Type.LONG;
 import static io.spine.server.storage.jdbc.Type.STRING_255;
 
 /**
  * Holds {@link Timestamp} records by {@code String} IDs.
  */
-public final class TimestampByString extends MessageTable<String, Timestamp> {
+public final class TimestampByString extends TimestampTable<String> {
 
     private static final String NAME = "timestamp_by_string";
 
     public TimestampByString(DataSourceWrapper dataSource, TypeMapping typeMapping) {
-        super(NAME, IdColumn.of(Column.ID), dataSource, typeMapping);
+        super(NAME, IdColumn.of(TheIdColumn.INSTANCE), dataSource, typeMapping);
     }
 
-    @Override
-    public void write(Timestamp record) {
-        super.write(record);
-    }
-
-    @Override
-    public ResultSet resultSet(String id) {
-        return super.resultSet(id);
-    }
-
-    @Override
-    public ResultSet resultSet(Iterable<String> ids) {
-        return super.resultSet(ids);
-    }
-
-    /**
-     * Reads a given ID back from the database as a {@link ResultSet}.
-     *
-     * <p>Allows to obtain a {@link ResultSet} with a message ID which is sometimes necessary in
-     * tests.
-     */
-    public ResultSet resultSetWithId(String id) {
-        SelectMessageId.Builder<String, Timestamp> queryBuilder = SelectMessageId
-                .<String, Timestamp>newBuilder()
-                .setDataSource(dataSource())
-                .setTableName(name())
-                .setIdColumn(idColumn())
-                .setId(id);
-        SelectMessageId<String, Timestamp> query = queryBuilder.build();
-        ResultSet resultSet = query.getResults();
-        return resultSet;
-    }
-
-    public SelectTimestampById<String> composeSelectTimestampById(String id) {
-        SelectTimestampById.Builder<String> builder = SelectTimestampById
-                .<String>newBuilder()
-                .setDataSource(dataSource())
-                .setTableName(name())
-                .setMessageColumnName(bytesColumn().name())
-                .setMessageDescriptor(Timestamp.getDescriptor())
-                .setIdColumn(idColumn())
-                .setId(id);
-        SelectTimestampById<String> query = builder.build();
-        return query;
-    }
-
-    @Override
-    public String idOf(Timestamp record) {
-        return super.idOf(record);
-    }
-
-    @Override
-    protected Descriptor messageDescriptor() {
-        return Timestamp.getDescriptor();
-    }
-
-    @Override
-    protected Iterable<Column> messageSpecificColumns() {
-        return ImmutableList.copyOf(Column.values());
-    }
-
-    enum Column implements MessageTable.Column<Timestamp> {
-        ID(STRING_255, Timestamps::toString),
-        SECONDS(LONG, Timestamp::getSeconds),
-        NANOS(INT, Timestamp::getNanos);
-
-        private final Type type;
-        private final Getter<Timestamp> getter;
-
-        Column(Type type, Getter<Timestamp> getter) {
-            this.type = type;
-            this.getter = getter;
-        }
+    public enum TheIdColumn implements MessageTable.Column<Timestamp> {
+        INSTANCE;
 
         @Override
         public Getter<Timestamp> getter() {
-            return getter;
+            return Timestamps::toString;
         }
 
         @Override
         public Type type() {
-            return type;
+            return STRING_255;
         }
 
         @Override
         public boolean isPrimaryKey() {
-            return this == ID;
+            return true;
         }
 
         @Override

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampByString.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampByString.java
@@ -27,8 +27,9 @@ import com.google.protobuf.util.Timestamps;
 import io.spine.server.storage.jdbc.DataSourceWrapper;
 import io.spine.server.storage.jdbc.Type;
 import io.spine.server.storage.jdbc.TypeMapping;
+import io.spine.server.storage.jdbc.given.query.SelectMessageId;
+import io.spine.server.storage.jdbc.given.query.SelectTimestampById;
 import io.spine.server.storage.jdbc.message.MessageTable;
-import io.spine.server.storage.jdbc.message.SelectSingleMessage;
 import io.spine.server.storage.jdbc.query.IdColumn;
 
 import java.sql.ResultSet;
@@ -48,6 +49,21 @@ public final class TimestampByString extends MessageTable<String, Timestamp> {
         super(NAME, IdColumn.of(Column.ID), dataSource, typeMapping);
     }
 
+    @Override
+    public void write(Timestamp record) {
+        super.write(record);
+    }
+
+    @Override
+    public ResultSet resultSet(String id) {
+        return super.resultSet(id);
+    }
+
+    @Override
+    public ResultSet resultSet(Iterable<String> ids) {
+        return super.resultSet(ids);
+    }
+
     /**
      * Reads a given ID back from the database as a {@link ResultSet}.
      *
@@ -62,14 +78,21 @@ public final class TimestampByString extends MessageTable<String, Timestamp> {
                 .setIdColumn(idColumn())
                 .setId(id);
         SelectMessageId<String, Timestamp> query = queryBuilder.build();
-        ResultSet resultSet = query.query()
-                                   .getResults();
+        ResultSet resultSet = query.getResults();
         return resultSet;
     }
 
-    @Override
-    public SelectSingleMessage<String, Timestamp> composeSelectQuery(String id) {
-        return super.composeSelectQuery(id);
+    public SelectTimestampById<String> composeSelectTimestampById(String id) {
+        SelectTimestampById.Builder<String> builder = SelectTimestampById
+                .<String>newBuilder()
+                .setDataSource(dataSource())
+                .setTableName(name())
+                .setMessageColumnName(bytesColumn().name())
+                .setMessageDescriptor(Timestamp.getDescriptor())
+                .setIdColumn(idColumn())
+                .setId(id);
+        SelectTimestampById<String> query = builder.build();
+        return query;
     }
 
     @Override

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampTable.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampTable.java
@@ -58,14 +58,10 @@ abstract class TimestampTable<I> extends MessageTable<I, Timestamp> {
         super.write(record);
     }
 
-    @Override
     public ResultSet resultSet(I id) {
-        return super.resultSet(id);
-    }
-
-    @Override
-    public ResultSet resultSet(Iterable<I> ids) {
-        return super.resultSet(ids);
+        SelectTimestampById<I> query = composeSelectTimestampById(id);
+        ResultSet resultSet = query.getResults();
+        return resultSet;
     }
 
     @Override

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampTable.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampTable.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.jdbc.given.table;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Timestamp;
+import io.spine.server.storage.jdbc.DataSourceWrapper;
+import io.spine.server.storage.jdbc.Type;
+import io.spine.server.storage.jdbc.TypeMapping;
+import io.spine.server.storage.jdbc.given.query.SelectMessageId;
+import io.spine.server.storage.jdbc.given.query.SelectTimestampById;
+import io.spine.server.storage.jdbc.message.MessageTable;
+import io.spine.server.storage.jdbc.query.IdColumn;
+
+import java.sql.ResultSet;
+
+import static io.spine.server.storage.jdbc.Type.INT;
+import static io.spine.server.storage.jdbc.Type.LONG;
+
+/**
+ * Holds {@link Timestamp} records by some ID.
+ *
+ * <p>Overrides several {@link MessageTable} methods to expose them to all tests.
+ *
+ * @param <I>
+ *         the ID type
+ */
+abstract class TimestampTable<I> extends MessageTable<I, Timestamp> {
+
+    TimestampTable(String name,
+                   IdColumn<I> idColumn,
+                   DataSourceWrapper dataSource,
+                   TypeMapping typeMapping) {
+        super(name, idColumn, dataSource, typeMapping);
+    }
+
+    @Override
+    public void write(Timestamp record) {
+        super.write(record);
+    }
+
+    @Override
+    public ResultSet resultSet(I id) {
+        return super.resultSet(id);
+    }
+
+    @Override
+    public ResultSet resultSet(Iterable<I> ids) {
+        return super.resultSet(ids);
+    }
+
+    @Override
+    public I idOf(Timestamp record) {
+        return super.idOf(record);
+    }
+
+    @Override
+    protected Descriptor messageDescriptor() {
+        return Timestamp.getDescriptor();
+    }
+
+    @SuppressWarnings("unchecked") // Guaranteed by class descendants.
+    @Override
+    protected Iterable<? extends MessageTable.Column<Timestamp>> messageSpecificColumns() {
+        MessageTable.Column<Timestamp> idColumn =
+                (MessageTable.Column<Timestamp>) idColumn().column();
+        return ImmutableSet.of(idColumn, Column.SECONDS, Column.NANOS);
+    }
+
+    /**
+     * Reads a given ID back from the database as a {@link ResultSet}.
+     */
+    public ResultSet resultSetWithId(I id) {
+        SelectMessageId.Builder<I, Timestamp> queryBuilder = SelectMessageId
+                .<I, Timestamp>newBuilder()
+                .setDataSource(dataSource())
+                .setTableName(name())
+                .setIdColumn(idColumn())
+                .setId(id);
+        SelectMessageId<I, Timestamp> query = queryBuilder.build();
+        ResultSet resultSet = query.getResults();
+        return resultSet;
+    }
+
+    /**
+     * Composes a "select-timestamp-by-ID" query.
+     */
+    public SelectTimestampById<I> composeSelectTimestampById(I id) {
+        SelectTimestampById.Builder<I> builder = SelectTimestampById
+                .<I>newBuilder()
+                .setDataSource(dataSource())
+                .setTableName(name())
+                .setMessageColumnName(bytesColumn().name())
+                .setMessageDescriptor(Timestamp.getDescriptor())
+                .setIdColumn(idColumn())
+                .setId(id);
+        SelectTimestampById<I> query = builder.build();
+        return query;
+    }
+
+    public enum Column implements MessageTable.Column<Timestamp> {
+        SECONDS(LONG, Timestamp::getSeconds),
+        NANOS(INT, Timestamp::getNanos);
+
+        private final Type type;
+        private final Getter<Timestamp> getter;
+
+        Column(Type type, Getter<Timestamp> getter) {
+            this.type = type;
+            this.getter = getter;
+        }
+
+        @Override
+        public Getter<Timestamp> getter() {
+            return getter;
+        }
+
+        @Override
+        public Type type() {
+            return type;
+        }
+
+        @Override
+        public boolean isPrimaryKey() {
+            return false;
+        }
+
+        @Override
+        public boolean isNullable() {
+            return false;
+        }
+    }
+}

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampTable.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/TimestampTable.java
@@ -39,7 +39,7 @@ import static io.spine.server.storage.jdbc.Type.LONG;
 /**
  * Holds {@link Timestamp} records by some ID.
  *
- * <p>Overrides several {@link MessageTable} methods to expose them to all tests.
+ * <p>Overrides several {@link MessageTable} methods to expose them to tests.
  *
  * @param <I>
  *         the ID type
@@ -78,7 +78,7 @@ abstract class TimestampTable<I> extends MessageTable<I, Timestamp> {
         return Timestamp.getDescriptor();
     }
 
-    @SuppressWarnings("unchecked") // Guaranteed by class descendants.
+    @SuppressWarnings("unchecked") // Ensured by class descendants.
     @Override
     protected Iterable<? extends MessageTable.Column<Timestamp>> messageSpecificColumns() {
         MessageTable.Column<Timestamp> idColumn =

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/package-info.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/table/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * This class contains sample SQL tables that can be filled with data and then queried.
+ */
+
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.server.storage.jdbc.given.table;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/projection/JdbcProjectionStorageTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/projection/JdbcProjectionStorageTest.java
@@ -26,7 +26,6 @@ import io.spine.server.projection.ProjectionStorage;
 import io.spine.server.projection.ProjectionStorageTest;
 import io.spine.server.storage.given.RecordStorageTestEnv.TestCounterEntity;
 import io.spine.server.storage.jdbc.DataSourceWrapper;
-import io.spine.server.storage.jdbc.GivenDataSource;
 import io.spine.server.storage.jdbc.StorageBuilder;
 import io.spine.server.storage.jdbc.TypeMapping;
 import io.spine.server.storage.jdbc.record.JdbcRecordStorage;
@@ -35,7 +34,9 @@ import io.spine.test.storage.ProjectId;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
+import static io.spine.base.Identifier.newUuid;
+import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
 import static io.spine.testing.Tests.nullRef;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -47,11 +48,11 @@ class JdbcProjectionStorageTest extends ProjectionStorageTest {
     @Override
     protected ProjectionStorage<ProjectId> newStorage(Class<? extends Entity<?, ?>> entityClass) {
         DataSourceWrapper dataSource =
-                GivenDataSource.whichIsStoredInMemory("projectionStorageTests");
+                whichIsStoredInMemory("projectionStorageTests");
         @SuppressWarnings("unchecked") // Required for the tests.
                 Class<? extends Projection<ProjectId, ?, ?>> projectionClass =
                 (Class<? extends Projection<ProjectId, ?, ?>>) entityClass;
-        TypeMapping typeMapping = MYSQL_5_7;
+        TypeMapping typeMapping = H2_1_4;
         JdbcRecordStorage<ProjectId> entityStorage =
                 JdbcRecordStorage.<ProjectId>newBuilder()
                         .setDataSource(dataSource)
@@ -84,7 +85,7 @@ class JdbcProjectionStorageTest extends ProjectionStorageTest {
     void acceptDatasourceInBuilder() {
         StorageBuilder<?, ?> builder =
                 JdbcProjectionStorage.newBuilder()
-                                     .setDataSource(GivenDataSource.withoutSuperpowers());
+                                     .setDataSource(whichIsStoredInMemory(newUuid()));
         assertNotNull(builder);
     }
 

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/projection/SelectTimestampQueryTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/projection/SelectTimestampQueryTest.java
@@ -32,7 +32,7 @@ import java.sql.SQLException;
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
-import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 @DisplayName("SelectTimestampQuery should")
@@ -43,7 +43,7 @@ class SelectTimestampQueryTest {
     void returnNullForEmptyTimestamp() throws SQLException {
         DataSourceWrapper dataSource = whichIsStoredInMemory(newUuid());
 
-        LastHandledEventTimeTable table = new LastHandledEventTimeTable(dataSource, MYSQL_5_7);
+        LastHandledEventTimeTable table = new LastHandledEventTimeTable(dataSource, H2_1_4);
         table.create();
         String tableName = table.name();
 

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/AbstractQueryTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/AbstractQueryTest.java
@@ -62,7 +62,7 @@ class AbstractQueryTest {
 
     @Test
     @DisplayName("specify a `TransactionHandler` as one of the transaction listeners")
-    void handleExceptionOnRollback() {
+    void injectTransactionHandler() {
         Configuration configuration = query.factory()
                                            .getConfiguration();
         SQLListeners listeners = configuration.getListeners();

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/AbstractQueryTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/AbstractQueryTest.java
@@ -66,6 +66,7 @@ class AbstractQueryTest {
         Configuration configuration = query.factory()
                                            .getConfiguration();
         SQLListeners listeners = configuration.getListeners();
-        assertThat(listeners.getListeners()).contains(TransactionHandler.INSTANCE);
+        assertThat(listeners.getListeners())
+                .contains(TransactionHandler.INSTANCE);
     }
 }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/AbstractQueryTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/AbstractQueryTest.java
@@ -20,13 +20,10 @@
 
 package io.spine.server.storage.jdbc.query;
 
-import com.querydsl.sql.AbstractSQLQueryFactory;
 import com.querydsl.sql.Configuration;
-import com.querydsl.sql.SQLListenerContext;
 import com.querydsl.sql.SQLListeners;
-import io.spine.server.storage.jdbc.ConnectionWrapper;
 import io.spine.server.storage.jdbc.DataSourceWrapper;
-import io.spine.server.storage.jdbc.DatabaseException;
+import io.spine.server.storage.jdbc.query.AbstractQuery.TransactionHandler;
 import io.spine.server.storage.jdbc.query.given.Given.AStorageQuery;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,18 +31,11 @@ import org.junit.jupiter.api.Test;
 import java.sql.Connection;
 import java.sql.SQLException;
 
+import static com.google.common.truth.Truth.assertThat;
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
-import static io.spine.server.storage.jdbc.query.AbstractQuery.createFactory;
 import static io.spine.server.storage.jdbc.query.given.Given.storageQueryBuilder;
 import static java.sql.ResultSet.HOLD_CURSORS_OVER_COMMIT;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 @DisplayName("AbstractQuery should")
 class AbstractQueryTest {
@@ -55,20 +45,6 @@ class AbstractQueryTest {
                                                              .setDataSource(dataSource)
                                                              .build();
 
-    @Test
-    @DisplayName("close connection")
-    void closeConnection() throws SQLException {
-        Configuration configuration = query.factory()
-                                           .getConfiguration();
-        SQLListenerContext context = mock(SQLListenerContext.class);
-        Connection connection = mock(Connection.class);
-        doReturn(connection).when(context)
-                            .getConnection();
-        configuration.getListeners()
-                     .end(context);
-        verify(connection).close();
-    }
-
     /**
      * A commit is executed after a query execution, but a {@code ResultSet} should be used after
      * this, hence the result set should not be closed. This test verifies that the correct
@@ -77,48 +53,19 @@ class AbstractQueryTest {
     @Test
     @DisplayName("set `HOLD_CURSORS_OVER_COMMIT` for connection")
     void holdCursorsOverCommit() throws SQLException {
-        DataSourceWrapper dataSourceSpy = spy(dataSource);
-        ConnectionWrapper connectionWrapper = spy(dataSourceSpy.getConnection(true));
-        Connection connection = spy(connectionWrapper.get());
-        doReturn(connectionWrapper).when(dataSourceSpy)
-                                   .getConnection(anyBoolean());
-        doReturn(connection).when(connectionWrapper)
-                            .get();
-        AbstractSQLQueryFactory<?> factory = createFactory(dataSourceSpy);
-        Connection connectionFromFactory = factory.getConnection();
+        Connection connection = query.factory()
+                                     .getConnection();
 
-        // The test can only verify that the holdability was set.
-        // The result of the operation depends on a JDBC implementation.
-        verify(connectionFromFactory).setHoldability(HOLD_CURSORS_OVER_COMMIT);
+        assertThat(connection.getHoldability())
+                .isEqualTo(HOLD_CURSORS_OVER_COMMIT);
     }
 
     @Test
-    @DisplayName("handle SQL exception on transaction rollback")
-    void handleExceptionOnRollback() throws SQLException {
+    @DisplayName("specify a `TransactionHandler` as one of the transaction listeners")
+    void handleExceptionOnRollback() {
         Configuration configuration = query.factory()
                                            .getConfiguration();
-        SQLListenerContext context = mock(SQLListenerContext.class);
-        Connection connection = mock(Connection.class);
-        doThrow(SQLException.class).when(connection)
-                                   .rollback();
-        doReturn(connection).when(context)
-                            .getConnection();
         SQLListeners listeners = configuration.getListeners();
-        assertThrows(DatabaseException.class, () -> listeners.exception(context));
-    }
-
-    @Test
-    @DisplayName("handle SQL exception on transaction commit")
-    void handleExceptionOnCommit() throws SQLException {
-        Configuration configuration = query.factory()
-                                           .getConfiguration();
-        SQLListenerContext context = mock(SQLListenerContext.class);
-        Connection connection = mock(Connection.class);
-        doThrow(SQLException.class).when(connection)
-                                   .commit();
-        doReturn(connection).when(context)
-                            .getConnection();
-        SQLListeners listeners = configuration.getListeners();
-        assertThrows(DatabaseException.class, () -> listeners.executed(context));
+        assertThat(listeners.getListeners()).contains(TransactionHandler.INSTANCE);
     }
 }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/DbIteratorTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/DbIteratorTest.java
@@ -119,7 +119,7 @@ class DbIteratorTest {
 
     @Test
     @DisplayName("do nothing on close if result set is already closed")
-    void checkIfResultSetClosed() throws SQLException {
+    void doNothingIfAlreadyClosed() throws SQLException {
         DbIterator iterator = emptyIterator();
 
         ResultSet resultSet = iterator.resultSet();

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/DbIteratorTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/DbIteratorTest.java
@@ -24,22 +24,17 @@ import io.spine.server.storage.jdbc.DatabaseException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.InOrder;
 
-import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.NoSuchElementException;
 
+import static com.google.common.truth.Truth.assertThat;
 import static io.spine.server.storage.jdbc.query.given.DbIteratorTestEnv.emptyIterator;
 import static io.spine.server.storage.jdbc.query.given.DbIteratorTestEnv.faultyResultIterator;
 import static io.spine.server.storage.jdbc.query.given.DbIteratorTestEnv.nonEmptyIterator;
 import static io.spine.server.storage.jdbc.query.given.DbIteratorTestEnv.sneakyResultIterator;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 
 @SuppressWarnings({"InnerClassMayBeStatic", "ClassCanBeStatic"})
 // JUnit nested classes cannot be static.
@@ -53,16 +48,9 @@ class DbIteratorTest {
 
         @Test
         @DisplayName("on `hasNext` check failure")
-        void onNextCheckFailure() {
+        void onNextCheckFailure() throws SQLException {
             DbIterator iterator = faultyResultIterator();
             assertThrows(DatabaseException.class, iterator::hasNext);
-        }
-
-        @Test
-        @DisplayName("on close failure")
-        void onCloseFailure() {
-            DbIterator iterator = faultyResultIterator();
-            assertThrows(DatabaseException.class, iterator::close);
         }
 
         @Test
@@ -93,11 +81,8 @@ class DbIteratorTest {
         @DisplayName("when told to do so")
         void whenTold() throws SQLException {
             DbIterator iterator = nonEmptyIterator();
-            ResultSet resultSet = iterator.resultSet();
-
-            verify(resultSet, never()).close();
-
             iterator.close();
+
             assertClosed(iterator);
         }
 
@@ -106,11 +91,8 @@ class DbIteratorTest {
         @DisplayName("when no more elements are present to iterate")
         void whenNoElementsPresent() throws SQLException {
             DbIterator iterator = emptyIterator();
-            ResultSet resultSet = iterator.resultSet();
-
-            verify(resultSet, never()).close();
-
             iterator.hasNext();
+
             assertClosed(iterator);
         }
     }
@@ -136,51 +118,22 @@ class DbIteratorTest {
     }
 
     @Test
-    @DisplayName("check if result set is closed")
+    @DisplayName("do nothing on close if result set is already closed")
     void checkIfResultSetClosed() throws SQLException {
         DbIterator iterator = emptyIterator();
-        iterator.close();
 
         ResultSet resultSet = iterator.resultSet();
-        verify(resultSet).isClosed();
-        verify(resultSet).close();
-    }
+        resultSet.close();
+        assertThat(resultSet.isClosed())
+                .isTrue();
 
-    @Test
-    @DisplayName("obtain statement before result set is closed")
-    void getStatementBeforeClose() throws SQLException {
-        DbIterator iterator = emptyIterator();
         iterator.close();
-
-        ResultSet resultSet = iterator.resultSet();
-        InOrder order = inOrder(resultSet);
-        order.verify(resultSet)
-             .getStatement();
-        order.verify(resultSet)
-             .close();
-    }
-
-    @Test
-    @DisplayName("obtain connection before statement is closed")
-    void getConnectionBeforeClose() throws SQLException {
-        DbIterator iterator = emptyIterator();
-        iterator.close();
-
-        Statement statement = iterator.resultSet()
-                                      .getStatement();
-        InOrder order = inOrder(statement);
-        order.verify(statement)
-             .getConnection();
-        order.verify(statement)
-             .close();
+        assertClosed(iterator);
     }
 
     private static void assertClosed(DbIterator<?> iterator) throws SQLException {
         ResultSet resultSet = iterator.resultSet();
-        Statement statement = resultSet.getStatement();
-        Connection connection = statement.getConnection();
-        verify(resultSet).close();
-        verify(statement).close();
-        verify(connection).close();
+        assertThat(resultSet.isClosed())
+                .isTrue();
     }
 }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/QueryExecutorTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/QueryExecutorTest.java
@@ -21,42 +21,24 @@
 package io.spine.server.storage.jdbc.query;
 
 import io.spine.logging.Logging;
-import io.spine.server.storage.jdbc.ConnectionWrapper;
 import io.spine.server.storage.jdbc.DataSourceWrapper;
 import io.spine.server.storage.jdbc.DatabaseException;
+import io.spine.server.storage.jdbc.GivenDataSource;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-
 import static io.spine.base.Identifier.newUuid;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 
 @DisplayName("QueryExecutor should")
 class QueryExecutorTest implements Logging {
 
     @Test
     @DisplayName("handle SQL exception on query execution")
-    void handleExceptionOnExecution() throws SQLException {
-        DataSourceWrapper dataSource = mock(DataSourceWrapper.class);
-        ConnectionWrapper connection = mock(ConnectionWrapper.class);
-        PreparedStatement statement = mock(PreparedStatement.class);
-
-        doReturn(connection).when(dataSource)
-                            .getConnection(anyBoolean());
-        doReturn(statement).when(connection)
-                           .prepareStatement(anyString());
-        doThrow(SQLException.class).when(statement)
-                                   .execute();
-        QueryExecutor query = spy(new QueryExecutor(dataSource, logger()));
-
-        assertThrows(DatabaseException.class, () -> query.execute(newUuid()));
+    void handleExceptionOnExecution() {
+        DataSourceWrapper dataSource = GivenDataSource.whichIsStoredInMemory(newUuid());
+        QueryExecutor executor = new QueryExecutor(dataSource, logger());
+        String erroneousQuery = "SELECT * FROM \"non-existent-table\"";
+        assertThrows(DatabaseException.class, () -> executor.execute(erroneousQuery));
     }
 }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/QueryExecutorTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/QueryExecutorTest.java
@@ -23,11 +23,11 @@ package io.spine.server.storage.jdbc.query;
 import io.spine.logging.Logging;
 import io.spine.server.storage.jdbc.DataSourceWrapper;
 import io.spine.server.storage.jdbc.DatabaseException;
-import io.spine.server.storage.jdbc.GivenDataSource;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static io.spine.base.Identifier.newUuid;
+import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("QueryExecutor should")
@@ -36,9 +36,10 @@ class QueryExecutorTest implements Logging {
     @Test
     @DisplayName("handle SQL exception on query execution")
     void handleExceptionOnExecution() {
-        DataSourceWrapper dataSource = GivenDataSource.whichIsStoredInMemory(newUuid());
+        DataSourceWrapper dataSource = whichIsStoredInMemory(newUuid());
         QueryExecutor executor = new QueryExecutor(dataSource, logger());
         String erroneousQuery = "SELECT * FROM \"non-existent-table\"";
+
         assertThrows(DatabaseException.class, () -> executor.execute(erroneousQuery));
     }
 }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/given/Given.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/given/Given.java
@@ -34,8 +34,8 @@ public class Given {
     /**
      * Returns the new builder for the test {@link SelectMessageByIdQuery} implementation.
      */
-    public static ASelectMessageByIdQuery.Builder selectMessageBuilder() {
-        return new ASelectMessageByIdQuery.Builder();
+    public static <I> ASelectMessageByIdQuery.Builder<I> selectMessageBuilder() {
+        return new ASelectMessageByIdQuery.Builder<>();
     }
 
     /**
@@ -45,11 +45,11 @@ public class Given {
         return new AStorageQuery.Builder();
     }
 
-    public static class ASelectMessageByIdQuery extends SelectMessageByIdQuery<String, Message> {
+    public static class ASelectMessageByIdQuery<I> extends SelectMessageByIdQuery<I, Message> {
 
         private final AbstractSQLQuery<?, ?> query;
 
-        private ASelectMessageByIdQuery(Builder builder) {
+        private ASelectMessageByIdQuery(Builder<I> builder) {
             super(builder);
             this.query = builder.query;
         }
@@ -59,25 +59,26 @@ public class Given {
             return query;
         }
 
-        public static class Builder extends SelectMessageByIdQuery.Builder<Builder,
-                                                                           ASelectMessageByIdQuery,
-                                                                           String,
-                                                                           Message> {
+        public static class Builder<I>
+                extends SelectMessageByIdQuery.Builder<Builder<I>,
+                                                       ASelectMessageByIdQuery<I>,
+                                                       I,
+                                                       Message> {
 
             private AbstractSQLQuery<?, ?> query;
 
-            public Builder setQuery(AbstractSQLQuery<?, ?> query) {
+            public Builder<I> setQuery(AbstractSQLQuery<?, ?> query) {
                 this.query = query;
                 return this;
             }
 
             @Override
-            protected ASelectMessageByIdQuery doBuild() {
-                return new ASelectMessageByIdQuery(this);
+            protected ASelectMessageByIdQuery<I> doBuild() {
+                return new ASelectMessageByIdQuery<>(this);
             }
 
             @Override
-            protected Builder getThis() {
+            protected Builder<I> getThis() {
                 return this;
             }
         }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/given/QueryPredicatesTestEnv.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/given/QueryPredicatesTestEnv.java
@@ -69,12 +69,12 @@ public final class QueryPredicatesTestEnv {
         public void setColumnValue(Parameters.Builder storageRecord,
                                    Object value,
                                    String columnIdentifier) {
-            // NO-OP. This method is not interesting for test.
+            // NO-OP. This method is not interesting for the test.
         }
 
         @Override
         public void setNull(Parameters.Builder storageRecord, String columnIdentifier) {
-            // NO-OP. This method is not interesting for test.
+            // NO-OP. This method is not interesting for the test.
         }
 
         @SuppressWarnings("ReturnOfNull") // OK for test.

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/given/QueryPredicatesTestEnv.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/given/QueryPredicatesTestEnv.java
@@ -66,7 +66,8 @@ public final class QueryPredicatesTestEnv {
         }
 
         @Override
-        public void setColumnValue(Parameters.Builder storageRecord, Object value,
+        public void setColumnValue(Parameters.Builder storageRecord,
+                                   Object value,
                                    String columnIdentifier) {
             // NO-OP. This method is not interesting for test.
         }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/given/QueryPredicatesTestEnv.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/given/QueryPredicatesTestEnv.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.jdbc.query.given;
+
+import io.spine.server.entity.storage.Column;
+import io.spine.server.entity.storage.EntityColumn;
+import io.spine.server.storage.jdbc.Type;
+import io.spine.server.storage.jdbc.query.Parameters;
+import io.spine.server.storage.jdbc.type.JdbcColumnType;
+
+import java.lang.reflect.Method;
+
+public final class QueryPredicatesTestEnv {
+
+    /** Prevents instantiation of this test env class. */
+    private QueryPredicatesTestEnv() {
+    }
+
+    public static NonComparableType nonComparableType() {
+        return new NonComparableType();
+    }
+
+    public static EntityColumn stringColumn() {
+        try {
+            Method method = QueryPredicatesTestEnv.class.getDeclaredMethod("getString");
+            EntityColumn column = EntityColumn.from(method);
+            return column;
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Column
+    public String getString() {
+        return "";
+    }
+
+    /**
+     * Returns a non-comparable object on attempt to convert an entity column value.
+     *
+     * <p>An entity column with such type should not be accepted during the column filter creation.
+     */
+    private static class NonComparableType implements JdbcColumnType<String, Object> {
+
+        @Override
+        public Object convertColumnValue(String fieldValue) {
+            return new Object();
+        }
+
+        @Override
+        public void setColumnValue(Parameters.Builder storageRecord, Object value,
+                                   String columnIdentifier) {
+            // NO-OP. This method is not interesting for test.
+        }
+
+        @Override
+        public void setNull(Parameters.Builder storageRecord, String columnIdentifier) {
+            // NO-OP. This method is not interesting for test.
+        }
+
+        @SuppressWarnings("ReturnOfNull") // OK for test.
+        @Override
+        public Type getType() {
+            return null;
+        }
+    }
+}

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/record/JdbcRecordStorageTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/record/JdbcRecordStorageTest.java
@@ -56,7 +56,7 @@ import static io.spine.client.Filters.gt;
 import static io.spine.client.Filters.lt;
 import static io.spine.server.storage.LifecycleFlagField.archived;
 import static io.spine.server.storage.LifecycleFlagField.deleted;
-import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
 import static io.spine.server.storage.jdbc.record.given.JdbcRecordStorageTestEnv.COLUMN_NAME_FOR_STORING;
 import static io.spine.testing.Tests.nullRef;
 import static java.util.stream.Collectors.toList;
@@ -171,7 +171,7 @@ class JdbcRecordStorageTest extends RecordStorageTest<JdbcRecordStorage<ProjectI
                         .setEntityClass(entityClass)
                         .setMultitenant(false)
                         .setColumnTypeRegistry(JdbcTypeRegistryFactory.defaultInstance())
-                        .setTypeMapping(MYSQL_5_7)
+                        .setTypeMapping(H2_1_4)
                         .build();
         return storage;
     }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/record/JdbcRecordStorageTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/record/JdbcRecordStorageTest.java
@@ -35,7 +35,6 @@ import io.spine.server.storage.RecordStorage;
 import io.spine.server.storage.RecordStorageTest;
 import io.spine.server.storage.given.RecordStorageTestEnv.TestCounterEntity;
 import io.spine.server.storage.jdbc.DataSourceWrapper;
-import io.spine.server.storage.jdbc.GivenDataSource;
 import io.spine.server.storage.jdbc.TableColumn;
 import io.spine.server.storage.jdbc.record.given.JdbcRecordStorageTestEnv.TestEntityWithStringId;
 import io.spine.server.storage.jdbc.type.JdbcColumnType;
@@ -56,6 +55,7 @@ import static io.spine.client.Filters.gt;
 import static io.spine.client.Filters.lt;
 import static io.spine.server.storage.LifecycleFlagField.archived;
 import static io.spine.server.storage.LifecycleFlagField.deleted;
+import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
 import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
 import static io.spine.server.storage.jdbc.record.given.JdbcRecordStorageTestEnv.COLUMN_NAME_FOR_STORING;
 import static io.spine.testing.Tests.nullRef;
@@ -161,7 +161,7 @@ class JdbcRecordStorageTest extends RecordStorageTest<JdbcRecordStorage<ProjectI
 
     @Override
     protected JdbcRecordStorage<ProjectId> newStorage(Class<? extends Entity<?, ?>> cls) {
-        DataSourceWrapper dataSource = GivenDataSource.whichIsStoredInMemory("entityStorageTests");
+        DataSourceWrapper dataSource = whichIsStoredInMemory("entityStorageTests");
         @SuppressWarnings("unchecked") // Test invariant.
                 Class<? extends Entity<ProjectId, ?>> entityClass =
                 (Class<? extends Entity<ProjectId, ?>>) cls;

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/type/JdbcTypeRegistryFactoryTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/type/JdbcTypeRegistryFactoryTest.java
@@ -20,13 +20,14 @@
 
 package io.spine.server.storage.jdbc.type;
 
-import io.spine.core.Version;
 import io.spine.server.entity.storage.ColumnTypeRegistry;
 import io.spine.server.storage.jdbc.type.given.JdbcTypeRegistryFactoryTestEnv.CustomType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.server.storage.jdbc.type.given.JdbcTypeRegistryFactoryTestEnv.columnWithType;
+import static io.spine.server.storage.jdbc.type.given.JdbcTypeRegistryFactoryTestEnv.booleanColumn;
+import static io.spine.server.storage.jdbc.type.given.JdbcTypeRegistryFactoryTestEnv.stringColumn;
+import static io.spine.server.storage.jdbc.type.given.JdbcTypeRegistryFactoryTestEnv.versionColumn;
 import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
 import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -46,8 +47,8 @@ class JdbcTypeRegistryFactoryTest {
     void provideDefaultRegistry() {
         ColumnTypeRegistry<?> registry = JdbcTypeRegistryFactory.defaultInstance();
         assertNotNull(registry);
-        assertNotNull(registry.get(columnWithType(Version.class)));
-        assertNotNull(registry.get(columnWithType(boolean.class)));
+        assertNotNull(registry.get(versionColumn()));
+        assertNotNull(registry.get(booleanColumn()));
     }
 
     @Test
@@ -58,8 +59,8 @@ class JdbcTypeRegistryFactoryTest {
                                        .put(String.class, CustomType.INSTANCE)
                                        .build();
         assertNotNull(registry);
-        assertNotNull(registry.get(columnWithType(Version.class)));
-        assertNotNull(registry.get(columnWithType(boolean.class)));
-        assertEquals(registry.get(columnWithType(String.class)), CustomType.INSTANCE);
+        assertNotNull(registry.get(versionColumn()));
+        assertNotNull(registry.get(booleanColumn()));
+        assertEquals(registry.get(stringColumn()), CustomType.INSTANCE);
     }
 }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/type/given/JdbcTypeRegistryFactoryTestEnv.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/type/given/JdbcTypeRegistryFactoryTestEnv.java
@@ -20,25 +20,57 @@
 
 package io.spine.server.storage.jdbc.type.given;
 
+import io.spine.core.Version;
+import io.spine.server.entity.storage.Column;
 import io.spine.server.entity.storage.EntityColumn;
 import io.spine.server.storage.jdbc.Type;
 import io.spine.server.storage.jdbc.query.Parameters;
 import io.spine.server.storage.jdbc.type.JdbcColumnType;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import java.lang.reflect.Method;
 
+@SuppressWarnings("unused") // Entity columns are used reflectively.
 public class JdbcTypeRegistryFactoryTestEnv {
 
     /** Prevents instantiation of this utility class. */
     private JdbcTypeRegistryFactoryTestEnv() {
     }
 
-    public static EntityColumn columnWithType(Class<?> cls) {
-        EntityColumn column = mock(EntityColumn.class);
-        when(column.type()).thenReturn(cls);
-        when(column.persistedType()).thenReturn(cls);
-        return column;
+    public static EntityColumn booleanColumn() {
+        return column("getBoolean");
+    }
+
+    public static EntityColumn versionColumn() {
+        return column("getVersion");
+    }
+
+    public static EntityColumn stringColumn() {
+        return column("getString");
+    }
+
+    private static EntityColumn column(String name) {
+        try {
+            Method method = JdbcTypeRegistryFactoryTestEnv.class.getDeclaredMethod(name);
+            EntityColumn column = EntityColumn.from(method);
+            return column;
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Column
+    public boolean getBoolean() {
+        return false;
+    }
+
+    @Column
+    public Version getVersion() {
+        return Version.getDefaultInstance();
+    }
+
+    @Column
+    public String getString() {
+        return "";
     }
 
     public enum CustomType implements JdbcColumnType<String, String> {

--- a/version.gradle
+++ b/version.gradle
@@ -18,10 +18,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-final def SPINE_VERSION = '1.1.0'
+final def SPINE_VERSION = '1.1.1-SNAPSHOT+1'
 
 ext {
     versionToPublish = SPINE_VERSION
-    spineBaseVersion = SPINE_VERSION
+    spineBaseVersion = '1.1.0'
     spineCoreVersion = SPINE_VERSION
 }


### PR DESCRIPTION
This PR removes Mockito usage from the `jdbc-storage` tests.

The Mockito dependency itself is removed from the configuration.

The Spine version updates to `1.1.1-SNAPSHOT+1`.