### PR TITLE
Update to Spine Core `1.2.5`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,14 @@ allprojects {
 
     group = 'io.spine'
     version = versionToPublish
+
+    configurations {
+        all {
+            resolutionStrategy {
+                force group: 'io.spine', name: 'spine-base', version: spineBaseVersion
+            }
+        }
+    }
 }
 
 subprojects {

--- a/license-report.md
+++ b/license-report.md
@@ -1,13 +1,12 @@
 
     
-# Dependencies of `io.spine:spine-rdbms:1.2.0`
+# Dependencies of `io.spine:spine-rdbms:1.2.5`
 
 ## Runtime
 1. **Group:** com.google.auto.value **Name:** auto-value-annotations **Version:** 1.6.3
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -30,12 +29,10 @@
 
 1. **Group:** com.google.guava **Name:** failureaccess **Version:** 1.0.1
      * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.guava **Name:** guava **Version:** 28.1-jre
      * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.guava **Name:** guava-testlib **Version:** 28.1-jre
@@ -50,12 +47,10 @@
 
 1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.10.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
 1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.10.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
 1. **Group:** com.google.truth **Name:** truth **Version:** 1.0
@@ -71,12 +66,10 @@
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.googlecode.java-diff-utils **Name:** diffutils **Version:** 1.3.0
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM Project URL:** [http://code.google.com/p/java-diff-utils/](http://code.google.com/p/java-diff-utils/)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.h2database **Name:** h2 **Version:** 1.4.196
-     * **Manifest license URL:** [http://www.h2database.com/html/license.html](http://www.h2database.com/html/license.html)
      * **POM Project URL:** [http://www.h2database.com](http://www.h2database.com)
      * **POM License: MPL 2.0 or EPL 1.0** - [http://h2database.com/html/license.html](http://h2database.com/html/license.html)
 
@@ -88,23 +81,19 @@
 
 1. **Group:** com.querydsl **Name:** querydsl-core **Version:** 4.1.4
      * **Manifest Project URL:** [http://www.querydsl.com](http://www.querydsl.com)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM Project URL:** [${project.homepage}](${project.homepage})
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.querydsl **Name:** querydsl-sql **Version:** 4.1.4
      * **Manifest Project URL:** [http://www.querydsl.com](http://www.querydsl.com)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.zaxxer **Name:** HikariCP **Version:** 2.4.3
      * **Manifest Project URL:** [https://github.com/brettwooldridge](https://github.com/brettwooldridge)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM Project URL:** [https://github.com/brettwooldridge/HikariCP](https://github.com/brettwooldridge/HikariCP)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** javax.validation **Name:** validation-api **Version:** 1.1.0.Final
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM Project URL:** [http://beanvalidation.org](http://beanvalidation.org)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -119,7 +108,6 @@
 
 1. **Group:** org.apache.servicemix.bundles **Name:** org.apache.servicemix.bundles.javax-inject **Version:** 1_2
      * **Manifest Project URL:** [http://www.apache.org/](http://www.apache.org/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** org.apiguardian **Name:** apiguardian-api **Version:** 1.0.0
@@ -131,7 +119,8 @@
      * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
-1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.9.0
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 3.0.0
+     * **Manifest License:** MIT (Not packaged)
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
@@ -149,15 +138,15 @@
      * **POM Project URL:** [http://hsqldb.org](http://hsqldb.org)
      * **POM License: HSQLDB License, a BSD open source license** - [http://hsqldb.org/web/hsqlLicense.html](http://hsqldb.org/web/hsqlLicense.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.1
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.2
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.1
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.2
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.1
+1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.2
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
@@ -166,13 +155,12 @@
      * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.slf4j **Name:** slf4j-api **Version:** 1.7.26
+1. **Group:** org.slf4j **Name:** slf4j-api **Version:** 1.7.29
      * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
      * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 
 ## Compile, tests and tooling
 1. **Group:** com.beust **Name:** jcommander **Version:** 1.72
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM Project URL:** [http://jcommander.org](http://jcommander.org)
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -195,7 +183,6 @@
      * **POM License: GNU Lesser Public License** - [http://www.gnu.org/licenses/lgpl.html](http://www.gnu.org/licenses/lgpl.html)
 
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -231,12 +218,10 @@
 
 1. **Group:** com.google.guava **Name:** failureaccess **Version:** 1.0.1
      * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.guava **Name:** guava **Version:** 28.1-jre
      * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.guava **Name:** guava-testlib **Version:** 28.1-jre
@@ -251,12 +236,10 @@
 
 1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.10.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
 1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.10.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
 1. **Group:** com.google.truth **Name:** truth **Version:** 1.0
@@ -272,12 +255,10 @@
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.googlecode.java-diff-utils **Name:** diffutils **Version:** 1.3.0
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM Project URL:** [http://code.google.com/p/java-diff-utils/](http://code.google.com/p/java-diff-utils/)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.h2database **Name:** h2 **Version:** 1.4.196
-     * **Manifest license URL:** [http://www.h2database.com/html/license.html](http://www.h2database.com/html/license.html)
      * **POM Project URL:** [http://www.h2database.com](http://www.h2database.com)
      * **POM License: MPL 2.0 or EPL 1.0** - [http://h2database.com/html/license.html](http://h2database.com/html/license.html)
 
@@ -289,40 +270,35 @@
 
 1. **Group:** com.querydsl **Name:** querydsl-core **Version:** 4.1.4
      * **Manifest Project URL:** [http://www.querydsl.com](http://www.querydsl.com)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM Project URL:** [${project.homepage}](${project.homepage})
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.querydsl **Name:** querydsl-sql **Version:** 4.1.4
      * **Manifest Project URL:** [http://www.querydsl.com](http://www.querydsl.com)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.zaxxer **Name:** HikariCP **Version:** 2.4.3
      * **Manifest Project URL:** [https://github.com/brettwooldridge](https://github.com/brettwooldridge)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM Project URL:** [https://github.com/brettwooldridge/HikariCP](https://github.com/brettwooldridge/HikariCP)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** commons-io **Name:** commons-io **Version:** 2.6
      * **Project URL:** [http://commons.apache.org/proper/commons-io/](http://commons.apache.org/proper/commons-io/)
-     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.24.1
+1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.25.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.24.1
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.25.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.24.1
+1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.25.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
 1. **Group:** javax.validation **Name:** validation-api **Version:** 1.1.0.Final
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM Project URL:** [http://beanvalidation.org](http://beanvalidation.org)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -339,10 +315,10 @@
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.16.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.19.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.16.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.19.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
 1. **Group:** net.sourceforge.saxon **Name:** saxon **Version:** 9.1.0.8
@@ -351,17 +327,14 @@
 
 1. **Group:** org.antlr **Name:** antlr4-runtime **Version:** 4.7
      * **Manifest Project URL:** [http://www.antlr.org](http://www.antlr.org)
-     * **Manifest license URL:** [http://www.antlr.org/license.html](http://www.antlr.org/license.html)
      * **POM License: The BSD License** - [http://www.antlr.org/license.html](http://www.antlr.org/license.html)
 
 1. **Group:** org.apache.commons **Name:** commons-lang3 **Version:** 3.8.1
      * **Project URL:** [http://commons.apache.org/proper/commons-lang/](http://commons.apache.org/proper/commons-lang/)
-     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** org.apache.servicemix.bundles **Name:** org.apache.servicemix.bundles.javax-inject **Version:** 1_2
      * **Manifest Project URL:** [http://www.apache.org/](http://www.apache.org/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** org.apiguardian **Name:** apiguardian-api **Version:** 1.0.0
@@ -373,7 +346,8 @@
      * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
-1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.9.0
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 3.0.0
+     * **Manifest License:** MIT (Not packaged)
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
@@ -402,38 +376,34 @@
      * **POM License: HSQLDB License, a BSD open source license** - [http://hsqldb.org/web/hsqlLicense.html](http://hsqldb.org/web/hsqlLicense.html)
 
 1. **Group:** org.jacoco **Name:** org.jacoco.agent **Version:** 0.8.4
-     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
      * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
 1. **Group:** org.jacoco **Name:** org.jacoco.ant **Version:** 0.8.4
-     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
      * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
 1. **Group:** org.jacoco **Name:** org.jacoco.core **Version:** 0.8.4
-     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
      * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
 1. **Group:** org.jacoco **Name:** org.jacoco.report **Version:** 0.8.4
-     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
      * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.1
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.2
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.1
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.2
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.1
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.2
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.1
+1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.2
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.1
+1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.2
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
@@ -470,7 +440,7 @@
      * **POM Project URL:** [http://pcollections.org](http://pcollections.org)
      * **POM License: The MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 
-1. **Group:** org.slf4j **Name:** slf4j-api **Version:** 1.7.26
+1. **Group:** org.slf4j **Name:** slf4j-api **Version:** 1.7.29
      * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
      * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 
@@ -479,4 +449,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 08 15:52:12 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 22 16:40:07 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>jdbc-storage</artifactId>
-<version>1.2.0</version>
+<version>1.2.5</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -70,19 +70,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.5</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.5</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>org.checkerframework</groupId>
     <artifactId>checker-qual</artifactId>
-    <version>2.9.0</version>
+    <version>3.0.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -94,25 +94,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.grpc</groupId>
     <artifactId>grpc-stub</artifactId>
-    <version>1.24.1</version>
+    <version>1.25.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.3</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.3</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-engine</artifactId>
-    <version>5.5.1</version>
+    <version>5.5.2</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -128,7 +128,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>
     <artifactId>pmd-java</artifactId>
-    <version>6.16.0</version>
+    <version>6.19.0</version>
   </dependency>
   <dependency>
     <groupId>org.jacoco</groupId>

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/JdbcInboxStorage.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/JdbcInboxStorage.java
@@ -31,6 +31,7 @@ import io.spine.server.storage.jdbc.StorageBuilder;
 import io.spine.server.storage.jdbc.message.JdbcMessageStorage;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -72,6 +73,14 @@ public class JdbcInboxStorage
         checkNotClosed();
         Iterator<InboxMessage> iterator = table().readAll(index);
         return new InboxPage(iterator, pageSize);
+    }
+
+    @Override
+    public Optional<InboxMessage> oldestMessageToDeliver(ShardIndex index) {
+        checkNotNull(index);
+        checkNotClosed();
+        Optional<InboxMessage> result = table().readOldestToDeliver(index);
+        return result;
     }
 
     /**

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/SelectOldestMessageToDeliver.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/SelectOldestMessageToDeliver.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.jdbc.delivery;
+
+import com.google.protobuf.Descriptors;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.sql.AbstractSQLQuery;
+import io.spine.server.delivery.InboxMessage;
+
+import static com.querydsl.core.types.Order.DESC;
+import static io.spine.server.delivery.InboxMessageStatus.TO_DELIVER;
+import static io.spine.server.storage.jdbc.delivery.InboxTable.Column.SHARD_INDEX;
+import static io.spine.server.storage.jdbc.delivery.InboxTable.Column.WHEN_RECEIVED;
+import static io.spine.server.storage.jdbc.delivery.InboxTable.Column.WHEN_RECEIVED_NANOS;
+import static io.spine.server.storage.jdbc.message.MessageTable.bytesColumn;
+
+/**
+ * Selects the oldest {@code InboxMessage} in
+ * {@link io.spine.server.delivery.InboxMessageStatus#TO_DELIVER TO_DELIVER} status.
+ */
+public class SelectOldestMessageToDeliver extends SelectByShardIndexQuery<InboxMessage> {
+
+    private SelectOldestMessageToDeliver(Builder builder) {
+        super(builder);
+    }
+
+    @Override
+    protected AbstractSQLQuery<Object, ?> query() {
+        OrderSpecifier<Comparable> bySeconds = orderBy(WHEN_RECEIVED, DESC);
+        OrderSpecifier<Comparable> byNanos = orderBy(WHEN_RECEIVED_NANOS, DESC);
+        return factory().select(pathOf(bytesColumn()))
+                        .from(table())
+                        .where(pathOf(SHARD_INDEX).eq(shardIndex()),
+                               pathOf(InboxTable.Column.STATUS).eq(TO_DELIVER.toString()))
+                        .orderBy(bySeconds, byNanos)
+                        .limit(1);
+
+    }
+
+    @Override
+    protected Descriptors.Descriptor messageDescriptor() {
+        return InboxMessage.getDescriptor();
+    }
+
+    static Builder newBuilder() {
+        return new Builder();
+    }
+
+    static class Builder
+            extends SelectByShardIndexQuery.Builder<Builder, SelectOldestMessageToDeliver> {
+
+        @Override
+        protected Builder getThis() {
+            return this;
+        }
+
+        @Override
+        protected SelectOldestMessageToDeliver doBuild() {
+            return new SelectOldestMessageToDeliver(this);
+        }
+    }
+}

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcDeliverySmokeTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcDeliverySmokeTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.jdbc.delivery;
+
+import io.spine.server.ServerEnvironment;
+import io.spine.server.delivery.DeliveryTest;
+import io.spine.server.storage.StorageFactory;
+import io.spine.server.storage.jdbc.JdbcStorageFactory;
+import io.spine.testing.SlowTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+
+import static io.spine.base.Identifier.newUuid;
+import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
+
+/**
+ * Smoke tests on {@link Delivery} functionality running on top of JDBC-accessible storage.
+ */
+@DisplayName("JDBC-backed `Delivery` should ")
+@SlowTest
+class JdbcDeliverySmokeTest extends DeliveryTest {
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+        StorageFactory factory = JdbcStorageFactory
+                .newBuilder()
+                .setDataSource(whichIsStoredInMemory(newUuid()))
+                .setTypeMapping(H2_1_4)
+                .build();
+        ServerEnvironment.instance()
+                         .configureStorageForTests(factory);
+
+    }
+}

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcDeliverySmokeTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcDeliverySmokeTest.java
@@ -23,10 +23,14 @@ package io.spine.server.storage.jdbc.delivery;
 import io.spine.server.ServerEnvironment;
 import io.spine.server.delivery.DeliveryTest;
 import io.spine.server.storage.StorageFactory;
+import io.spine.server.storage.jdbc.DataSourceWrapper;
 import io.spine.server.storage.jdbc.JdbcStorageFactory;
 import io.spine.testing.SlowTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
@@ -34,22 +38,129 @@ import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
 
 /**
  * Smoke tests on {@link Delivery} functionality running on top of JDBC-accessible storage.
+ *
+ * <p>The tests are extremely slow, so only a tiny portion of the original {@link DeliveryTest}
+ * is launched.
  */
 @DisplayName("JDBC-backed `Delivery` should ")
 @SlowTest
 class JdbcDeliverySmokeTest extends DeliveryTest {
 
+    private StorageFactory factory;
+
     @Override
     @BeforeEach
     public void setUp() {
         super.setUp();
-        StorageFactory factory = JdbcStorageFactory
+        DataSourceWrapper source = whichIsStoredInMemory(newUuid());
+        factory = JdbcStorageFactory
                 .newBuilder()
-                .setDataSource(whichIsStoredInMemory(newUuid()))
+                .setDataSource(source)
                 .setTypeMapping(H2_1_4)
                 .build();
         ServerEnvironment.instance()
                          .configureStorageForTests(factory);
+    }
 
+    @AfterEach
+    @Override
+    public void tearDown() {
+        super.tearDown();
+        try {
+            factory.close();
+        } catch (Exception e) {
+            throw new IllegalStateException("Cannot close the storage factory", e);
+        }
+    }
+
+    @Test
+    @DisplayName("deliver messages via multiple shards to multiple targets in a multi-threaded env")
+    @Override
+    public void manyTargets_manyShards_manyThreads() {
+        super.manyTargets_manyShards_manyThreads();
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void markDelivered() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void singleTarget_singleShard_manyThreads() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void manyTargets_singleShard_manyThreads() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void singleTarget_manyShards_manyThreads() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void singleTarget_manyShards_singleThread() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void singleTarget_singleShard_singleThread() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void manyTargets_singleShard_singleThread() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void manyTargets_manyShards_singleThread() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void withCustomStrategy() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void calculateStats() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void returnOptionalEmptyIfPicked() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void notifyDeliveryMonitorOfDeliveryCompletion() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void deliverInBatch() {
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void deliverMessagesInOrderOfEmission() {
     }
 }

--- a/version.gradle
+++ b/version.gradle
@@ -18,10 +18,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-final def SPINE_VERSION = '1.2.0'
+final def SPINE_VERSION = '1.2.5'
 
 ext {
     versionToPublish = SPINE_VERSION
-    spineBaseVersion = SPINE_VERSION
+    spineBaseVersion = '1.2.3'
     spineCoreVersion = SPINE_VERSION
 }


### PR DESCRIPTION
This PR updates the API to the Spine Core in version `1.2.5`.

**Notable changes**

* A column for `InboxMessage.version` has been added.
* Delivery` tests running on top of in-memory JDBC storage are added.

The library version is set to `1.2.5`.