### PR TITLE
Release `1.6.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Gradle:
 ```groovy
 dependencies {
     implementation (
-        "io.spine:spine-rdbms:1.5.0"
+        "io.spine:spine-rdbms:1.6.0"
     )
 }
 ```

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-rdbms:1.5.21`
+# Dependencies of `io.spine:spine-rdbms:1.6.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -528,4 +528,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jun 24 18:20:20 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 08 22:58:09 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>jdbc-storage</artifactId>
-<version>1.5.21</version>
+<version>1.6.0</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -64,13 +64,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>1.5.21</version>
+    <version>1.6.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>1.5.21</version>
+    <version>1.6.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -94,13 +94,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.5.21</version>
+    <version>1.6.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.5.21</version>
+    <version>1.6.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -19,6 +19,6 @@
  */
 
 
-val spineCoreVersion by extra("1.5.21")
+val spineCoreVersion by extra("1.6.0")
 val versionToPublish by extra(spineCoreVersion)
-val spineBaseVersion by extra("1.5.21")
+val spineBaseVersion by extra("1.6.0")


### PR DESCRIPTION
This PR does the release of a library version `1.6.0`.

The library as of now is still in the [experimental](https://github.com/SpineEventEngine/jdbc-storage/pull/149) status.

### Infrastructure

The project build scripts are migrated to Kotlin (#148).