### PR TITLE
[1.x] Explicitly close `DsIterator` and release JDBC connections

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-rdbms:1.7.0`
+# Dependencies of `io.spine:spine-rdbms:1.7.1-SNAPSHOT.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -467,4 +467,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Dec 15 10:12:47 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 18:19:55 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>jdbc-storage</artifactId>
-<version>1.7.0</version>
+<version>1.7.1-SNAPSHOT.2</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorage.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorage.java
@@ -106,16 +106,6 @@ public class JdbcAggregateStorage<I> extends AggregateStorage<I> {
         mainTable.insert(id, record);
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * <p><b>NOTE:</b> it is required to call {@link Iterator#hasNext()} before
-     * {@link Iterator#next()}.
-     *
-     * @return a new {@link DbIterator} instance
-     * @throws DatabaseException
-     *         if an error occurs during an interaction with the DB
-     */
     @Override
     protected Iterator<AggregateEventRecord> historyBackward(AggregateReadRequest<I> request)
             throws DatabaseException {

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorage.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorage.java
@@ -26,6 +26,7 @@
 
 package io.spine.server.storage.jdbc.aggregate;
 
+import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Timestamp;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.AggregateEventRecord;
@@ -40,14 +41,11 @@ import io.spine.server.storage.jdbc.query.DbIterator;
 import io.spine.server.storage.jdbc.query.DbIterator.DoubleColumnRecord;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.Lists.newLinkedList;
 import static com.google.common.collect.Streams.stream;
-import static io.spine.server.storage.jdbc.aggregate.Closeables.closeAll;
 
 /**
  * The implementation of the aggregate storage based on the RDBMS.
@@ -65,17 +63,6 @@ public class JdbcAggregateStorage<I> extends AggregateStorage<I> {
 
     private final DataSourceWrapper dataSource;
 
-    /**
-     * The {@linkplain #historyBackward(AggregateReadRequest) history} iterators,
-     * which are not {@linkplain DbIterator#close() closed} yet.
-     *
-     * <p>{@link DbIterator} will be closed automatically only
-     * if all elements were {@linkplain DbIterator#hasNext() iterated}.
-     *
-     * <p>Because history iterators are used to go through a part of a history,
-     * they should be closed by the storage.
-     */
-    private final Collection<DbIterator> iterators = newLinkedList();
     private final AggregateEventRecordTable<I> mainTable;
     private final LifecycleFlagsTable<I> lifecycleFlagsTable;
 
@@ -138,8 +125,9 @@ public class JdbcAggregateStorage<I> extends AggregateStorage<I> {
         int fetchSize = request.batchSize();
         SelectEventRecordsById<I> query = mainTable.composeSelectQuery(id);
         DbIterator<AggregateEventRecord> historyIterator = query.execute(fetchSize);
-        iterators.add(historyIterator);
-        return historyIterator;
+        ImmutableList<AggregateEventRecord> records = ImmutableList.copyOf(historyIterator);
+        historyIterator.close();
+        return records.iterator();
     }
 
     @Override
@@ -157,11 +145,17 @@ public class JdbcAggregateStorage<I> extends AggregateStorage<I> {
         return mainTable.index();
     }
 
+    @SuppressWarnings("TryFinallyCanBeTryWithResources")    /* For better readability. */
     private void doTruncate(int snapshotIndex, @Nullable Timestamp date) {
         DbIterator<DoubleColumnRecord<I, Integer>> records =
                 selectVersionsToPersist(snapshotIndex, date);
-        stream(records)
-                .forEach(record -> mainTable.deletePriorRecords(record.first(), record.second()));
+        try {
+            stream(records)
+                    .forEach(record -> mainTable.deletePriorRecords(record.first(),
+                                                                    record.second()));
+        } finally {
+            records.close();
+        }
     }
 
     private DbIterator<DoubleColumnRecord<I, Integer>>
@@ -169,15 +163,11 @@ public class JdbcAggregateStorage<I> extends AggregateStorage<I> {
         SelectVersionBySnapshot<I> query =
                 mainTable.composeSelectVersionQuery(snapshotIndex, date);
         DbIterator<DoubleColumnRecord<I, Integer>> iterator = query.execute();
-        iterators.add(iterator);
         return iterator;
     }
 
     /**
      * Closes the storage.
-     *
-     * <p>Unclosed {@linkplain #iterators history iterators}
-     * produced by this storage will be closed together with the storage.
      *
      * @throws DatabaseException
      *         if the underlying datasource cannot be closed
@@ -185,9 +175,7 @@ public class JdbcAggregateStorage<I> extends AggregateStorage<I> {
     @Override
     public void close() throws DatabaseException {
         super.close();
-        closeAll(iterators);
         dataSource.close();
-        iterators.clear();
     }
 
     /**

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 
 val spineCoreVersion by extra("1.7.0")
 val spineBaseVersion by extra("1.7.0")
-val versionToPublish by extra("1.7.1-SNAPSHOT.1")
+val versionToPublish by extra("1.7.1-SNAPSHOT.2")


### PR DESCRIPTION
Previously, the `AggregateStorage` routines were making an extensive use of `DbIterator`s. This is a special `Iterator` version which would traverse through the records obtained from some RDBMS via an open JDBC connection. For convenience, it was made to automatically close as soon as all of the records are traversed.

The problem is that `DbIterator` served to read the Aggregate history up until the most recent snapshot. As long as the snapshot record could be not the last one, the iterator was not closed automatically. Realising that, `AggregateStorage` collected all the `DbIterator` left-overs with an intention to close them once the `AggregateStorage` itself closed.

The `Aggregate` truncation was implemented in a similar fashion.

While that was a nice strategy, in fact we were just holding those open JDBC connections forever — since no `AggregateStorage` could ever be closed in a real life.

This changeset addresses the issue by explicitly closing the `DsIterator` once it is no longer needed.

The library version is set to `1.7.1-SNAPSHOT.2`.