### PR TITLE
Release 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.spine:spine-rdbms:1.7.0")
+    implementation("io.spine:spine-rdbms:1.8.0")
 }
 ```
 

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-rdbms:1.7.1-SNAPSHOT.2`
+# Dependencies of `io.spine:spine-rdbms:1.8.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -467,4 +467,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Nov 23 18:19:55 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Dec 17 13:45:48 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>jdbc-storage</artifactId>
-<version>1.7.1-SNAPSHOT.2</version>
+<version>1.8.0</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -46,7 +46,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -88,19 +88,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/ShardedWorkRegistryTable.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/ShardedWorkRegistryTable.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Descriptors.Descriptor;
 import io.spine.server.delivery.ShardIndex;
 import io.spine.server.delivery.ShardSessionRecord;
+import io.spine.server.delivery.WorkerId;
 import io.spine.server.storage.jdbc.DataSourceWrapper;
 import io.spine.server.storage.jdbc.Type;
 import io.spine.server.storage.jdbc.TypeMapping;
@@ -98,8 +99,11 @@ final class ShardedWorkRegistryTable extends MessageTable<ShardIndex, ShardSessi
         OF_TOTAL_SHARDS(LONG, m -> m.getIndex()
                                     .getOfTotal()),
 
-        NODE_ID(STRING_255, m -> m.getPickedBy()
-                                  .getValue()),
+        WORKER_ID(STRING_255, m -> {
+                WorkerId worker = m.getWorker();
+                String result = worker.getNodeId().getValue() + '-' + worker.getValue();
+                return result;
+        }),
 
         WHEN_LAST_PICKED(LONG, m -> m.getWhenLastPicked()
                                      .getSeconds()),

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,6 +25,6 @@
  */
 
 
-val spineCoreVersion by extra("1.7.0")
-val spineBaseVersion by extra("1.7.0")
-val versionToPublish by extra("1.7.1-SNAPSHOT.2")
+val spineCoreVersion by extra("1.8.0")
+val spineBaseVersion by extra("1.8.0")
+val versionToPublish by extra("1.8.0")


### PR DESCRIPTION
This changeset releases the version `1.8.0`.

In particular, there are several changes made to the codebase:

* `JdbcShardedWorkRegistry` has been migrated to the new API introduced in [core-java#1433](https://github.com/SpineEventEngine/core-java/pull/1433).
* The versions of Spine dependencies were set to `1.8.0` as well.
* `README.md` now references the new version.
* License report files were updated.