### PR TITLE
Allow to order and limit records properly

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -46,9 +46,6 @@
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
-    <XML>
-      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
-    </XML>
     <codeStyleSettings language="Dart">
       <option name="RIGHT_MARGIN" value="100" />
       <indentOptions>

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-rdbms:1.8.0`
+# Dependencies of `io.spine:spine-rdbms:1.8.1`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -467,4 +467,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Dec 17 13:45:48 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 15 16:17:54 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>jdbc-storage</artifactId>
-<version>1.8.0</version>
+<version>1.8.1</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -46,7 +46,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -94,7 +94,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -147,15 +147,40 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>com.google.errorprone</groupId>
+    <artifactId>error_prone_core</artifactId>
+    <version>2.4.0</version>
+  </dependency>
+  <dependency>
+    <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_type_annotations</artifactId>
     <version>2.4.0</version>
     <scope>provided</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.google.errorprone</groupId>
+    <artifactId>javac</artifactId>
+    <version>9+181-r4173-1</version>
+  </dependency>
+  <dependency>
+    <groupId>net.sourceforge.pmd</groupId>
+    <artifactId>pmd-java</artifactId>
+    <version>6.24.0</version>
   </dependency>
   <dependency>
     <groupId>org.checkerframework</groupId>
     <artifactId>checker-qual</artifactId>
     <version>3.7.1</version>
     <scope>provided</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.jacoco</groupId>
+    <artifactId>org.jacoco.agent</artifactId>
+    <version>0.8.5</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jacoco</groupId>
+    <artifactId>org.jacoco.ant</artifactId>
+    <version>0.8.5</version>
   </dependency>
 </dependencies>
 </project>

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/query/AbstractQuery.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/query/AbstractQuery.java
@@ -74,6 +74,7 @@ public abstract class AbstractQuery implements StorageQuery {
     private final PathBuilder<Object> pathBuilder;
     private final PathBuilder<Object> aliasedPathBuilder;
 
+    @SuppressWarnings("rawtypes")   /* To simplify the signature. */
     protected AbstractQuery(Builder<? extends Builder, ? extends StorageQuery> builder) {
         String tableName = builder.tableName;
         this.queryFactory = createFactory(builder.dataSource);
@@ -122,6 +123,7 @@ public abstract class AbstractQuery implements StorageQuery {
         return pathBuilder.get(columnName, type);
     }
 
+    @SuppressWarnings("rawtypes")   /* The exact type of `Comparable` is not known here. */
     protected <T extends Comparable> ComparablePath<T>
     comparablePathOf(TableColumn column, Class<T> type) {
         return pathBuilder.getComparable(column.name(), type);
@@ -131,11 +133,13 @@ public abstract class AbstractQuery implements StorageQuery {
         return aliasedPathBuilder.get(column.name());
     }
 
+    @SuppressWarnings("rawtypes")   /* The exact type of `Comparable` is not known here. */
     protected <T extends Comparable> ComparablePath<T>
     aliasedComparablePathOf(TableColumn column, Class<T> type) {
         return aliasedPathBuilder.getComparable(column.name(), type);
     }
 
+    @SuppressWarnings("rawtypes")   /* The exact type of `Comparable` is not known here. */
     protected OrderSpecifier<Comparable> orderBy(TableColumn column, Order order) {
         PathBuilder<Comparable> columnPath = pathBuilder.get(column.name(), Comparable.class);
         return new OrderSpecifier<>(order, columnPath);

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/record/InsertEntityQuery.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/record/InsertEntityQuery.java
@@ -61,11 +61,11 @@ class InsertEntityQuery<I> extends WriteEntityQuery<I, SQLInsertClause> {
     }
 
     static class Builder<I> extends WriteEntityQuery.Builder<Builder<I>,
-                                                             InsertEntityQuery,
+                                                             InsertEntityQuery<I>,
                                                              I> {
 
         @Override
-        protected InsertEntityQuery doBuild() {
+        protected InsertEntityQuery<I> doBuild() {
             return new InsertEntityQuery<>(this);
         }
 

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/record/RecordTable.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/record/RecordTable.java
@@ -54,12 +54,12 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Lists.newLinkedList;
 import static com.google.common.collect.Streams.stream;
 import static io.spine.server.storage.jdbc.Type.BYTE_ARRAY;
 import static io.spine.server.storage.jdbc.record.RecordTable.StandardColumn.ID;
 import static java.util.Collections.addAll;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A table for storing the {@linkplain EntityRecord entity records}.
@@ -106,7 +106,7 @@ final class RecordTable<I> extends EntityTable<I, EntityRecord, EntityRecordWith
     @Override
     protected WriteQuery composeInsertQuery(I id, EntityRecordWithColumns record) {
         InsertEntityQuery.Builder<I> builder = InsertEntityQuery.newBuilder();
-        InsertEntityQuery query = builder.setDataSource(dataSource())
+        InsertEntityQuery<I> query = builder.setDataSource(dataSource())
                                          .setTableName(name())
                                          .setIdColumn(idColumn())
                                          .setColumnMapping(columnMapping)
@@ -118,7 +118,7 @@ final class RecordTable<I> extends EntityTable<I, EntityRecord, EntityRecordWith
     @Override
     protected WriteQuery composeUpdateQuery(I id, EntityRecordWithColumns record) {
         UpdateEntityQuery.Builder<I> builder = UpdateEntityQuery.newBuilder();
-        UpdateEntityQuery query = builder.setTableName(name())
+        UpdateEntityQuery<I> query = builder.setTableName(name())
                                          .setDataSource(dataSource())
                                          .setIdColumn(idColumn())
                                          .addRecord(id, record)
@@ -157,9 +157,15 @@ final class RecordTable<I> extends EntityTable<I, EntityRecord, EntityRecordWith
      */
     Iterator<EntityRecord> readByIds(EntityQuery<I> entityQuery, FieldMask fieldMask) {
         Iterator<DoubleColumnRecord<I, EntityRecord>> response =
-                executeQuery(entityQuery, fieldMask);
+                executeQuery(entityQuery, formatWithMask(fieldMask));
         Iterator<EntityRecord> records = extractRecordsForIds(entityQuery.getIds(), response);
         return records;
+    }
+
+    private static ResponseFormat formatWithMask(FieldMask fieldMask) {
+        return ResponseFormat.newBuilder()
+                             .setFieldMask(fieldMask)
+                             .vBuild();
     }
 
     /**
@@ -171,8 +177,7 @@ final class RecordTable<I> extends EntityTable<I, EntityRecord, EntityRecordWith
      * {@link #readByIds(EntityQuery, FieldMask)} counterpart.
      */
     Iterator<EntityRecord> readByQuery(EntityQuery<I> entityQuery, ResponseFormat format) {
-        Iterator<DoubleColumnRecord<I, EntityRecord>> response =
-                executeQuery(entityQuery, format.getFieldMask());
+        Iterator<DoubleColumnRecord<I, EntityRecord>> response = executeQuery(entityQuery, format);
         Iterator<EntityRecord> records = extractRecords(response);
         return records;
     }
@@ -181,29 +186,39 @@ final class RecordTable<I> extends EntityTable<I, EntityRecord, EntityRecordWith
      * Reads all {@linkplain EntityRecord entity records} from the table.
      */
     Iterator<EntityRecord> readAll(ResponseFormat format) {
-        Iterator<EntityRecord> result = executeSelectAllQuery(format.getFieldMask());
+        Iterator<EntityRecord> result = executeSelectAllQuery(format);
         return result;
     }
 
     private Iterator<DoubleColumnRecord<I, EntityRecord>>
-    executeQuery(EntityQuery<I> entityQuery, FieldMask fieldMask) {
-        SelectByEntityColumnsQuery.Builder<I> builder = SelectByEntityColumnsQuery.newBuilder();
-        SelectByEntityColumnsQuery<I> query = builder.setDataSource(dataSource())
-                                                     .setTableName(name())
-                                                     .setIdColumn(idColumn())
-                                                     .setColumnMapping(columnMapping)
-                                                     .setEntityQuery(entityQuery)
-                                                     .setFieldMask(fieldMask)
-                                                     .build();
+    executeQuery(EntityQuery<I> entityQuery, ResponseFormat format) {
+        SelectByEntityColumnsQuery.Builder<I> builder = queryBuilder(entityQuery, format);
+        SelectByEntityColumnsQuery<I> query = builder.build();
         Iterator<DoubleColumnRecord<I, EntityRecord>> queryResult = query.execute();
         return queryResult;
     }
 
-    private Iterator<EntityRecord> executeSelectAllQuery(FieldMask fieldMask) {
+    private SelectByEntityColumnsQuery.Builder<I>
+    queryBuilder(EntityQuery<I> entityQuery, ResponseFormat format) {
+        SelectByEntityColumnsQuery.Builder<I> builder = SelectByEntityColumnsQuery.newBuilder();
+        builder = builder.setDataSource(dataSource())
+                .setTableName(name())
+                .setIdColumn(idColumn())
+                .setColumnMapping(columnMapping)
+                .setEntityQuery(entityQuery)
+                .setFieldMask(format.getFieldMask())
+                .setOrdering(format.getOrderBy())
+                .setLimit(format.getLimit());
+        return builder;
+    }
+
+    private Iterator<EntityRecord> executeSelectAllQuery(ResponseFormat format) {
         SelectAllQuery.Builder builder = SelectAllQuery.newBuilder();
         SelectAllQuery query = builder.setDataSource(dataSource())
                                       .setTableName(name())
-                                      .setFieldMask(fieldMask)
+                                      .setFieldMask(format.getFieldMask())
+                                      .setOrdering(format.getOrderBy())
+                                      .setLimit(format.getLimit())
                                       .build();
         Iterator<EntityRecord> result = query.execute();
         return result;
@@ -232,7 +247,7 @@ final class RecordTable<I> extends EntityTable<I, EntityRecord, EntityRecordWith
 
     private WriteQuery newInsertEntityRecordsBulkQuery(Map<I, EntityRecordWithColumns> records) {
         InsertEntityQuery.Builder<I> builder = InsertEntityQuery.newBuilder();
-        InsertEntityQuery query = builder.setDataSource(dataSource())
+        InsertEntityQuery<I> query = builder.setDataSource(dataSource())
                                          .setTableName(name())
                                          .setIdColumn(idColumn())
                                          .setColumnMapping(columnMapping)
@@ -293,7 +308,7 @@ final class RecordTable<I> extends EntityTable<I, EntityRecord, EntityRecordWith
 
         @Override
         public TableColumn apply(@Nullable Column column) {
-            checkNotNull(column);
+            requireNonNull(column);
             TableColumn result = new ColumnWrapper(column, columnMapping);
             return result;
         }

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/record/UpdateEntityQuery.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/record/UpdateEntityQuery.java
@@ -61,11 +61,11 @@ class UpdateEntityQuery<I> extends WriteEntityQuery<I, SQLUpdateClause> {
     }
 
     static class Builder<I> extends WriteEntityQuery.Builder<Builder<I>,
-                                                             UpdateEntityQuery,
+                                                             UpdateEntityQuery<I>,
                                                              I> {
 
         @Override
-        protected UpdateEntityQuery doBuild() {
+        protected UpdateEntityQuery<I> doBuild() {
             return new UpdateEntityQuery<>(this);
         }
 

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/record/given/JdbcRecordStorageTestEnv.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/record/given/JdbcRecordStorageTestEnv.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.jdbc.record.given;
+
+import io.spine.base.Identifier;
+import io.spine.client.CompositeFilter;
+import io.spine.client.Filter;
+import io.spine.client.OrderBy;
+import io.spine.client.TargetFilters;
+import io.spine.protobuf.AnyPacker;
+import io.spine.server.entity.EntityRecord;
+import io.spine.server.entity.storage.EntityQueries;
+import io.spine.server.entity.storage.EntityQuery;
+import io.spine.server.storage.given.RecordStorageTestEnv.TestCounterEntity;
+import io.spine.server.storage.jdbc.record.JdbcRecordStorage;
+import io.spine.test.storage.ProjectId;
+
+import static io.spine.base.Identifier.newUuid;
+import static io.spine.client.CompositeFilter.CompositeOperator.ALL;
+import static io.spine.client.Filters.lt;
+import static io.spine.client.OrderBy.Direction.ASCENDING;
+import static io.spine.client.OrderBy.Direction.DESCENDING;
+import static io.spine.protobuf.AnyPacker.pack;
+import static io.spine.test.storage.Project.Status.CANCELLED;
+
+/**
+ * Test environment
+ * for {@link io.spine.server.storage.jdbc.record.JdbcRecordStorageTest JdbcRecordStorageTest}.
+ */
+public final class JdbcRecordStorageTestEnv {
+
+    private static final String STATUS_VALUE_COLNAME = "project_status_value";
+
+    private JdbcRecordStorageTestEnv() {
+    }
+
+    public static ProjectId unpackProjectId(EntityRecord next) {
+        return AnyPacker.unpack(next.getEntityId(), ProjectId.class);
+    }
+
+    public static ProjectId projectId() {
+        return ProjectId
+                .newBuilder()
+                .setId(newUuid())
+                .build();
+    }
+
+    public static String statusValueColumn() {
+        return STATUS_VALUE_COLNAME;
+    }
+
+    public static EntityRecord asEntityRecord(ProjectId id, TestCounterEntity entity) {
+        return EntityRecord
+                .newBuilder()
+                .setEntityId(Identifier.pack(id))
+                .setState(pack(entity.state()))
+                .setVersion(entity.version())
+                .setLifecycleFlags(entity.lifecycleFlags())
+                .build();
+    }
+
+    public static OrderBy ascendingByStatusValue() {
+        return orderByStatusValue(ASCENDING);
+    }
+
+    public static OrderBy descendingByStatusValue() {
+        return orderByStatusValue(DESCENDING);
+    }
+
+    private static OrderBy orderByStatusValue(OrderBy.Direction direction) {
+        return OrderBy.newBuilder()
+                      .setColumn(statusValueColumn())
+                      .setDirection(direction)
+                      .vBuild();
+    }
+
+    public static EntityQuery<ProjectId> queryAllBeforeCancelled(JdbcRecordStorage<ProjectId> storage) {
+        Filter lessThan = lt(statusValueColumn(), CANCELLED.getNumber());
+        CompositeFilter columnFilter = CompositeFilter
+                .newBuilder()
+                .addFilter(lessThan)
+                .setOperator(ALL)
+                .build();
+        TargetFilters filters = TargetFilters
+                .newBuilder()
+                .addFilter(columnFilter)
+                .build();
+        EntityQuery<ProjectId> query = EntityQueries.from(filters, storage);
+        return query;
+    }
+}

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/record/given/package-info.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/record/given/package-info.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test environment classes for tests of the {@link io.spine.server.storage.jdbc.record} package.
+ */
+
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.server.storage.jdbc.record.given;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,6 +25,6 @@
  */
 
 
-val spineCoreVersion by extra("1.8.0")
+val spineCoreVersion by extra("1.8.2-SNAPSHOT.1")
 val spineBaseVersion by extra("1.8.0")
-val versionToPublish by extra("1.8.0")
+val versionToPublish by extra("1.8.2-SNAPSHOT.1")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,6 +25,6 @@
  */
 
 
-val spineCoreVersion by extra("1.8.2-SNAPSHOT.1")
+val spineCoreVersion by extra("1.8.1")
 val spineBaseVersion by extra("1.8.0")
-val versionToPublish by extra("1.8.2-SNAPSHOT.1")
+val versionToPublish by extra("1.8.1")


### PR DESCRIPTION
Prior to this changeset, `EntityQuery` instances containing ordering and limiting directives were not handled properly. Specifically, the behaviour was broken for queries which targeted Projections and Process Managers.

This PR addresses the issue.