### PR TITLE
[1.x] Update to 1.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.spine:spine-rdbms:1.8.0")
+    implementation("io.spine:spine-rdbms:1.8.2")
 }
 ```
 

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-rdbms:1.8.1`
+# Dependencies of `io.spine:spine-rdbms:1.8.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -67,7 +67,7 @@
      * **Manifest Project URL:** [http://www.querydsl.com](http://www.querydsl.com)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.zaxxer **Name:** HikariCP **Version:** 3.4.5
+1. **Group:** com.zaxxer **Name:** HikariCP **Version:** 4.0.3
      * **Manifest Project URL:** [https://github.com/brettwooldridge](https://github.com/brettwooldridge)
      * **POM Project URL:** [https://github.com/brettwooldridge/HikariCP](https://github.com/brettwooldridge/HikariCP)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -243,9 +243,10 @@
      * **POM Project URL:** [http://code.google.com/p/java-diff-utils/](http://code.google.com/p/java-diff-utils/)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.h2database **Name:** h2 **Version:** 1.4.200
+1. **Group:** com.h2database **Name:** h2 **Version:** 2.1.214
      * **POM Project URL:** [https://h2database.com](https://h2database.com)
-     * **POM License: MPL 2.0 or EPL 1.0** - [https://h2database.com/html/license.html](https://h2database.com/html/license.html)
+     * **POM License: EPL 1.0** - [https://opensource.org/licenses/eclipse-1.0.php](https://opensource.org/licenses/eclipse-1.0.php)
+     * **POM License: MPL 2.0** - [https://www.mozilla.org/en-US/MPL/2.0/](https://www.mozilla.org/en-US/MPL/2.0/)
 
 1. **Group:** com.infradna.tool **Name:** bridge-method-annotation **Version:** 1.13
      * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
@@ -262,7 +263,7 @@
      * **Manifest Project URL:** [http://www.querydsl.com](http://www.querydsl.com)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.zaxxer **Name:** HikariCP **Version:** 3.4.5
+1. **Group:** com.zaxxer **Name:** HikariCP **Version:** 4.0.3
      * **Manifest Project URL:** [https://github.com/brettwooldridge](https://github.com/brettwooldridge)
      * **POM Project URL:** [https://github.com/brettwooldridge/HikariCP](https://github.com/brettwooldridge/HikariCP)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -467,4 +468,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jun 16 14:18:01 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 21 13:39:02 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>jdbc-storage</artifactId>
-<version>1.8.1</version>
+<version>1.8.2</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -40,13 +40,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.zaxxer</groupId>
     <artifactId>HikariCP</artifactId>
-    <version>3.4.5</version>
+    <version>4.0.3</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>1.8.1</version>
+    <version>1.8.2</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -76,7 +76,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.h2database</groupId>
     <artifactId>h2</artifactId>
-    <version>1.4.200</version>
+    <version>2.1.214</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -94,7 +94,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>1.8.1</version>
+    <version>1.8.2</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/rdbms/build.gradle.kts
+++ b/rdbms/build.gradle.kts
@@ -31,10 +31,11 @@ apply<IncrementGuard>()
 
 extra["artifactId"] = "jdbc-rdbms"
 
+// The latest version compatible with Java 8.
+val hikariVersion = "4.0.3"
 val querydslVersion = "4.4.0"
-val hikariVersion = "3.4.5"
 val hsqldbVersion = "2.5.1"
-val h2Version = "1.4.200"
+val h2Version = "2.1.214"
 
 dependencies {
     api("com.querydsl:querydsl-sql:$querydslVersion") {

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/PredefinedMapping.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/PredefinedMapping.java
@@ -41,7 +41,7 @@ public enum PredefinedMapping implements TypeMapping {
 
     MYSQL_5_7("MySQL", 5, 7, basicBuilder()),
     POSTGRESQL_10_1("PostgreSQL", 10, 1, basicBuilder().add(BYTE_ARRAY, "BYTEA")),
-    H2_1_4("H2", 1, 4, basicBuilder());
+    H2_2_1("H2", 2, 1, basicBuilder());
 
     @SuppressWarnings("NonSerializableFieldInSerializableClass")
     private final TypeMapping typeMapping;

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/DataSourceWrapperTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/DataSourceWrapperTest.java
@@ -35,7 +35,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsThrowingByCommand;
-import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_2_1;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("DataSourceWrapper should")
@@ -58,11 +58,11 @@ class DataSourceWrapperTest {
         DataSourceMetaData metaData = dataSourceWrapper.metaData();
 
         assertThat(metaData.productName())
-                .isEqualTo(H2_1_4.getDatabaseProductName());
+                .isEqualTo(H2_2_1.getDatabaseProductName());
         assertThat(metaData.majorVersion())
-                .isEqualTo(H2_1_4.getMajorVersion());
+                .isEqualTo(H2_2_1.getMajorVersion());
         assertThat(metaData.minorVersion())
-                .isEqualTo(H2_1_4.getMinorVersion());
+                .isEqualTo(H2_2_1.getMinorVersion());
     }
 
     @Test

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/JdbcStorageFactoryTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/JdbcStorageFactoryTest.java
@@ -45,7 +45,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichHoldsMetadata;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
-import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_2_1;
 import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_5_7;
 import static io.spine.server.storage.jdbc.given.JdbcStorageFactoryTestEnv.multitenantSpec;
 import static io.spine.server.storage.jdbc.given.JdbcStorageFactoryTestEnv.newFactory;
@@ -65,7 +65,7 @@ class JdbcStorageFactoryTest {
         JdbcStorageFactory factory = JdbcStorageFactory
                 .newBuilder()
                 .setDataSource(whichIsStoredInMemory(newUuid()))
-                .setTypeMapping(H2_1_4)
+                .setTypeMapping(H2_2_1)
                 .build();
 
         assertNotNull(factory);
@@ -178,7 +178,7 @@ class JdbcStorageFactoryTest {
         JdbcStorageFactory factory = JdbcStorageFactory
                 .newBuilder()
                 .setDataSource(dataSource)
-                .setTypeMapping(H2_1_4)
+                .setTypeMapping(H2_2_1)
                 .build();
         factory.close();
         assertThat(dataSource.isClosed())

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/AggregateEventRecordTableTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/AggregateEventRecordTableTest.java
@@ -38,7 +38,7 @@ import static io.spine.base.Identifier.newUuid;
 import static io.spine.base.Time.currentTime;
 import static io.spine.core.Versions.newVersion;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
-import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_2_1;
 import static io.spine.server.storage.jdbc.aggregate.AggregateEventRecordTable.Column.KIND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -52,7 +52,7 @@ class AggregateEventRecordTableTest {
         AggregateEventRecordTable<String> table =
                 new AggregateEventRecordTable<>(AnAggregate.class,
                                                 whichIsStoredInMemory(newUuid()),
-                                                H2_1_4);
+                                                H2_2_1);
         assertThrows(IllegalStateException.class,
                      () -> table.update(newUuid(), AggregateEventRecord.getDefaultInstance()));
     }
@@ -62,7 +62,7 @@ class AggregateEventRecordTableTest {
     void storeRecordKind() {
         DataSourceWrapper dataSource = whichIsStoredInMemory(newUuid());
         AggregateEventRecordTable<String> table =
-                new AggregateEventRecordTable<>(AnAggregate.class, dataSource, H2_1_4);
+                new AggregateEventRecordTable<>(AnAggregate.class, dataSource, H2_2_1);
         table.create();
 
         Snapshot snapshot = Snapshot.newBuilder()

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorageTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorageTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
-import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_2_1;
 import static io.spine.testing.Tests.nullRef;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -76,7 +76,7 @@ class JdbcAggregateStorageTest extends AggregateStorageTest {
         JdbcAggregateStorage<I> storage = builder.setMultitenant(false)
                                                  .setDataSource(dataSource)
                                                  .setAggregateClass(aggregateClass)
-                                                 .setTypeMapping(H2_1_4)
+                                                 .setTypeMapping(H2_2_1)
                                                  .build();
         return storage;
     }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorageVisibilityHandlingTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/aggregate/JdbcAggregateStorageVisibilityHandlingTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_2_1;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -58,7 +58,7 @@ class JdbcAggregateStorageVisibilityHandlingTest
                         .setMultitenant(false)
                         .setAggregateClass(TestAggregate.class)
                         .setDataSource(dataSource)
-                        .setTypeMapping(H2_1_4)
+                        .setTypeMapping(H2_2_1)
                         .build();
         return storage;
     }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcCatchUpSmokeTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcCatchUpSmokeTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
-import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_2_1;
 
 /**
  * Smoke tests on {@link io.spine.server.delivery.CatchUp CatchUp} functionality running
@@ -64,7 +64,7 @@ class JdbcCatchUpSmokeTest extends CatchUpTest {
         factory = JdbcStorageFactory
                 .newBuilder()
                 .setDataSource(source)
-                .setTypeMapping(H2_1_4)
+                .setTypeMapping(H2_2_1)
                 .build();
         ServerEnvironment
                 .when(Tests.class)

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcDeliverySmokeTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcDeliverySmokeTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
-import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_2_1;
 
 /**
  * Smoke tests on {@link Delivery} functionality running on top of JDBC-accessible storage.
@@ -63,7 +63,7 @@ class JdbcDeliverySmokeTest extends DeliveryTest {
         factory = JdbcStorageFactory
                 .newBuilder()
                 .setDataSource(source)
-                .setTypeMapping(H2_1_4)
+                .setTypeMapping(H2_2_1)
                 .build();
         ServerEnvironment
                 .when(Tests.class)

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcInboxStorageTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcInboxStorageTest.java
@@ -52,7 +52,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.spine.server.delivery.InboxMessageStatus.DELIVERED;
 import static io.spine.server.delivery.InboxMessageStatus.TO_DELIVER;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
-import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_2_1;
 import static io.spine.server.storage.jdbc.delivery.given.TestInboxMessage.generateMultiple;
 import static io.spine.server.storage.jdbc.delivery.given.TestShardIndex.newIndex;
 import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
@@ -74,7 +74,7 @@ class JdbcInboxStorageTest extends InboxStorageTest {
                 .newBuilder()
                 .setDataSource(dataSource)
                 .setMultitenant(false)
-                .setTypeMapping(H2_1_4)
+                .setTypeMapping(H2_2_1)
                 .build();
         super.setUp();
     }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcShardedWorkRegistryTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/delivery/JdbcShardedWorkRegistryTest.java
@@ -50,7 +50,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
-import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_2_1;
 import static io.spine.server.storage.jdbc.delivery.given.TestShardIndex.newIndex;
 import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
 
@@ -69,7 +69,7 @@ class JdbcShardedWorkRegistryTest extends ShardedWorkRegistryTest {
         JdbcStorageFactory storageFactory = JdbcStorageFactory
                 .newBuilder()
                 .setDataSource(dataSource)
-                .setTypeMapping(H2_1_4)
+                .setTypeMapping(H2_2_1)
                 .build();
         registry = new JdbcShardedWorkRegistry(storageFactory);
     }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/projection/JdbcProjectionStorageTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/projection/JdbcProjectionStorageTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
-import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_2_1;
 import static io.spine.testing.Tests.nullRef;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -57,7 +57,7 @@ class JdbcProjectionStorageTest extends ProjectionStorageTest {
         @SuppressWarnings("unchecked") // Required for the tests.
                 Class<? extends Projection<ProjectId, ?, ?>> projectionClass =
                 (Class<? extends Projection<ProjectId, ?, ?>>) entityClass;
-        TypeMapping typeMapping = H2_1_4;
+        TypeMapping typeMapping = H2_2_1;
         JdbcRecordStorage<ProjectId> entityStorage =
                 JdbcRecordStorage.<ProjectId>newBuilder()
                         .setDataSource(dataSource)

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/ColumnReaderTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/ColumnReaderTest.java
@@ -44,7 +44,7 @@ import java.sql.SQLException;
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
-import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_2_1;
 import static io.spine.server.storage.jdbc.query.ColumnReaderFactory.idReader;
 import static io.spine.server.storage.jdbc.query.ColumnReaderFactory.messageReader;
 
@@ -61,7 +61,7 @@ class ColumnReaderTest {
     @Test
     @DisplayName("read the value of an ID column of Number type")
     void readNumberId() throws SQLException {
-        TimestampByLong table = new TimestampByLong(dataSource, H2_1_4);
+        TimestampByLong table = new TimestampByLong(dataSource, H2_2_1);
         table.create();
 
         Timestamp timestamp = timestamp();
@@ -83,7 +83,7 @@ class ColumnReaderTest {
     @Test
     @DisplayName("read the value of an ID column of String type")
     void readStringId() throws SQLException {
-        TimestampByString table = new TimestampByString(dataSource, H2_1_4);
+        TimestampByString table = new TimestampByString(dataSource, H2_2_1);
         table.create();
 
         Timestamp timestamp = timestamp();
@@ -105,7 +105,7 @@ class ColumnReaderTest {
     @Test
     @DisplayName("read the value of an ID column of Message type")
     void readMessageId() throws SQLException {
-        TimestampByMessage table = new TimestampByMessage(dataSource, H2_1_4);
+        TimestampByMessage table = new TimestampByMessage(dataSource, H2_2_1);
         table.create();
 
         Timestamp timestamp = timestamp();
@@ -127,7 +127,7 @@ class ColumnReaderTest {
     @Test
     @DisplayName("read the value of a column storing serialized messages")
     void readSerializedMessage() throws SQLException {
-        TimestampByMessage table = new TimestampByMessage(dataSource, H2_1_4);
+        TimestampByMessage table = new TimestampByMessage(dataSource, H2_2_1);
         table.create();
 
         Timestamp timestamp = timestamp();

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/SelectMessageByIdQueryTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/SelectMessageByIdQueryTest.java
@@ -45,7 +45,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsThrowingByCommand;
-import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_2_1;
 import static io.spine.server.storage.jdbc.given.Column.stringIdColumn;
 import static io.spine.server.storage.jdbc.message.MessageTable.bytesColumn;
 import static io.spine.server.storage.jdbc.query.given.Given.selectMessageBuilder;
@@ -128,7 +128,7 @@ class SelectMessageByIdQueryTest {
     }
 
     private static TimestampByString table(DataSourceWrapper dataSource) {
-        TimestampByString table = new TimestampByString(dataSource, H2_1_4);
+        TimestampByString table = new TimestampByString(dataSource, H2_2_1);
         table.create();
         return table;
     }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/given/DbIteratorTestEnv.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/given/DbIteratorTestEnv.java
@@ -37,7 +37,7 @@ import java.sql.SQLException;
 
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
-import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_2_1;
 
 public class DbIteratorTestEnv {
 
@@ -75,7 +75,7 @@ public class DbIteratorTestEnv {
 
     private static ResultSet emptyResultSet() {
         DataSourceWrapper dataSource = whichIsStoredInMemory(newUuid());
-        TimestampByString table = new TimestampByString(dataSource, H2_1_4);
+        TimestampByString table = new TimestampByString(dataSource, H2_2_1);
         table.create();
 
         ResultSet resultSet = table.resultSet(newUuid());
@@ -84,7 +84,7 @@ public class DbIteratorTestEnv {
 
     private static ResultSet closedResultSet() throws SQLException {
         DataSourceWrapper dataSource = whichIsStoredInMemory(newUuid());
-        TimestampByString table = new TimestampByString(dataSource, H2_1_4);
+        TimestampByString table = new TimestampByString(dataSource, H2_2_1);
         table.create();
 
         ResultSet resultSet = table.resultSet(newUuid());
@@ -94,7 +94,7 @@ public class DbIteratorTestEnv {
 
     private static ResultSet resultSetWithSingleResult() {
         DataSourceWrapper dataSource = whichIsStoredInMemory(newUuid());
-        TimestampByString table = new TimestampByString(dataSource, H2_1_4);
+        TimestampByString table = new TimestampByString(dataSource, H2_2_1);
         table.create();
 
         Timestamp timestamp = Timestamp

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/record/JdbcRecordStorageTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/record/JdbcRecordStorageTest.java
@@ -63,7 +63,7 @@ import static io.spine.client.CompositeFilter.CompositeOperator.ALL;
 import static io.spine.client.Filters.gt;
 import static io.spine.client.Filters.lt;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory;
-import static io.spine.server.storage.jdbc.PredefinedMapping.H2_1_4;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_2_1;
 import static io.spine.server.storage.jdbc.record.given.JdbcRecordStorageTestEnv.asEntityRecord;
 import static io.spine.server.storage.jdbc.record.given.JdbcRecordStorageTestEnv.ascendingByStatusValue;
 import static io.spine.server.storage.jdbc.record.given.JdbcRecordStorageTestEnv.descendingByStatusValue;
@@ -346,7 +346,7 @@ class JdbcRecordStorageTest extends RecordStorageTest<JdbcRecordStorage<ProjectI
                         .setEntityClass(entityClass)
                         .setMultitenant(false)
                         .setColumnMapping(new DefaultJdbcColumnMapping())
-                        .setTypeMapping(H2_1_4)
+                        .setTypeMapping(H2_2_1)
                         .build();
         return storage;
     }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,6 +25,6 @@
  */
 
 
-val spineCoreVersion by extra("1.8.1")
+val spineCoreVersion by extra("1.8.2")
 val spineBaseVersion by extra("1.8.0")
-val versionToPublish by extra("1.8.1")
+val versionToPublish by extra("1.8.2")


### PR DESCRIPTION
This changeset updates the versions of `jdbc-storage` dependencies. In particular:

* `core-java` is updated to the latest `1.8.2` release;
* HikariCP version is set to`4.0.3`, which is the latest available version compatible with Java 8;
* H2 is now used in its latest `2.1.214` version, eliminating the currently known vulnerabilities.

Please note that H2 library is only used in the test code.

The own version of `jdbc-storage` modules is set to 1.8.2.