### PR TITLE
[1.x] Adjust publishing command

### DIFF
--- a/.github/workflows/publish-v1.yml
+++ b/.github/workflows/publish-v1.yml
@@ -60,7 +60,7 @@ jobs:
         # updated with the contents of 2.x branch. So this operation should be performed
         # manually, if really needed.
         # See https://github.com/SpineEventEngine/config/tree/master/scripts/publish-documentation.
-        run: ./gradlew publish -x test -x updateGitHubPages --stacktrace
+        run: ./gradlew publish -x test --stacktrace
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORMAL_GIT_HUB_PAGES_AUTHOR: developers@spine.io

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-rdbms:1.9.0-SNAPSHOT.2`
+# Dependencies of `io.spine:spine-rdbms:1.9.0-SNAPSHOT.3`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -468,4 +468,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 13 17:12:14 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 13 17:36:49 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>jdbc-storage</artifactId>
-<version>1.9.0-SNAPSHOT.2</version>
+<version>1.9.0-SNAPSHOT.3</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 
 val spineCoreVersion by extra("1.9.0-SNAPSHOT.10")
 val spineBaseVersion by extra("1.9.0-SNAPSHOT.5")
-val versionToPublish by extra("1.9.0-SNAPSHOT.2")
+val versionToPublish by extra("1.9.0-SNAPSHOT.3")


### PR DESCRIPTION
This PR modifies the publishing workflow, so that the `updateGitHubPages` is not excluded — as it does not exist in this scope.

The library version is set to `1.9.0-SNAPSHOT.3`.