### PR TITLE
[1.x] Widen the database-specific data type for `InboxId` and other IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,15 @@ If there is no predefined mapping for the database, mapping for MySQL 5.7 will b
 
 #### Default Values
 
-| Type         | MySQL 5.7     | PostgreSQL 10.1 |
-| :----------: |:-------------:| :--------------:|
-| BYTE_ARRAY   | BLOB          | BYTEA           |
-| INT          | INT           | INT             |
-| LONG         | BIGINT        | BIGINT          |
-| STRING_255   | VARCHAR(255)  | VARCHAR(255)    | 
-| STRING       | TEXT          | TEXT            |
-| BOOLEAN      | BOOLEAN       | BOOLEAN         |
+|    Type    |  MySQL 5.7   | PostgreSQL 10.1 |
+|:----------:|:------------:|:---------------:|
+| BYTE_ARRAY |     BLOB     |      BYTEA      |
+|    INT     |     INT      |       INT       |
+|    LONG    |    BIGINT    |     BIGINT      |
+| STRING_255 | VARCHAR(255) |  VARCHAR(255)   | 
+| STRING_512 | VARCHAR(512) |  VARCHAR(512)   | 
+|   STRING   |     TEXT     |      TEXT       |
+|  BOOLEAN   |   BOOLEAN    |     BOOLEAN     |
 
 #### Custom Mapping
 

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-rdbms:1.9.0-SNAPSHOT.3`
+# Dependencies of `io.spine:spine-rdbms:1.9.0-SNAPSHOT.4`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -468,4 +468,4 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 13 17:36:49 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 14 14:37:44 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>jdbc-storage</artifactId>
-<version>1.9.0-SNAPSHOT.3</version>
+<version>1.9.0-SNAPSHOT.4</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/Type.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/Type.java
@@ -57,6 +57,12 @@ public enum Type {
     STRING_255,
 
     /**
+     * The type representing a {@code String}, maximum length of which
+     * doesn't exceed 512 characters.
+     */
+    STRING_512,
+
+    /**
      * The type representing a {@code String}, maximum length of which is unknown.
      */
     STRING,

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/TypeMappingBuilder.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/TypeMappingBuilder.java
@@ -41,6 +41,7 @@ import static io.spine.server.storage.jdbc.Type.INT;
 import static io.spine.server.storage.jdbc.Type.LONG;
 import static io.spine.server.storage.jdbc.Type.STRING;
 import static io.spine.server.storage.jdbc.Type.STRING_255;
+import static io.spine.server.storage.jdbc.Type.STRING_512;
 
 /**
  * A builder for {@linkplain TypeMapping type mappings}.
@@ -58,6 +59,7 @@ public class TypeMappingBuilder {
      *     <li>{@code Type.INT} - {@code INT}</li>
      *     <li>{@code Type.LONG} - {@code BIGINT}</li>
      *     <li>{@code Type.STRING_255} - {@code VARCHAR(255)}</li>
+     *     <li>{@code Type.STRING_512} - {@code VARCHAR(512)}</li>
      *     <li>{@code Type.STRING} - {@code TEXT}</li>
      *     <li>{@code Type.BOOLEAN} - {@code BOOLEAN}</li>
      * </ul>
@@ -78,6 +80,7 @@ public class TypeMappingBuilder {
                                                              .add(INT, "INT")
                                                              .add(LONG, "BIGINT")
                                                              .add(STRING_255, "VARCHAR(255)")
+                                                             .add(STRING_512, "VARCHAR(512)")
                                                              .add(STRING, "TEXT")
                                                              .add(BOOLEAN, "BOOLEAN");
         return builder;

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/InboxTable.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/InboxTable.java
@@ -48,7 +48,7 @@ import static io.spine.server.storage.jdbc.Type.BOOLEAN;
 import static io.spine.server.storage.jdbc.Type.INT;
 import static io.spine.server.storage.jdbc.Type.LONG;
 import static io.spine.server.storage.jdbc.Type.STRING;
-import static io.spine.server.storage.jdbc.Type.STRING_255;
+import static io.spine.server.storage.jdbc.Type.STRING_512;
 
 /**
  * A table in the DB responsible for storing the {@link io.spine.server.delivery.Inbox Inbox} data.
@@ -122,10 +122,10 @@ final class InboxTable extends MessageTable<InboxMessageId, InboxMessage> {
 
         ID(InboxMessage::getId),
 
-        SIGNAL_ID(STRING_255, m -> m.getSignalId()
+        SIGNAL_ID(STRING_512, m -> m.getSignalId()
                                     .getValue()),
 
-        INBOX_ID(STRING_255, m -> Stringifiers.toString(m.getInboxId())),
+        INBOX_ID(STRING_512, m -> Stringifiers.toString(m.getInboxId())),
 
         SHARD_INDEX(LONG, m -> m.getId()
                                 .getIndex()

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/ShardedWorkRegistryTable.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/delivery/ShardedWorkRegistryTable.java
@@ -42,7 +42,7 @@ import java.util.Iterator;
 
 import static io.spine.server.storage.jdbc.Type.INT;
 import static io.spine.server.storage.jdbc.Type.LONG;
-import static io.spine.server.storage.jdbc.Type.STRING_255;
+import static io.spine.server.storage.jdbc.Type.STRING_512;
 
 /**
  * A table storing shard session {@linkplain ShardSessionRecord records}.
@@ -99,7 +99,7 @@ final class ShardedWorkRegistryTable extends MessageTable<ShardIndex, ShardSessi
         OF_TOTAL_SHARDS(LONG, m -> m.getIndex()
                                     .getOfTotal()),
 
-        WORKER_ID(STRING_255, m -> {
+        WORKER_ID(STRING_512, m -> {
                 WorkerId worker = m.getWorker();
                 String result = worker.getNodeId().getValue() + '-' + worker.getValue();
                 return result;

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/query/IdColumn.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/query/IdColumn.java
@@ -43,6 +43,7 @@ import static io.spine.server.entity.model.EntityClass.asEntityClass;
 import static io.spine.server.storage.jdbc.Type.INT;
 import static io.spine.server.storage.jdbc.Type.LONG;
 import static io.spine.server.storage.jdbc.Type.STRING;
+import static io.spine.server.storage.jdbc.Type.STRING_255;
 import static io.spine.server.storage.jdbc.Type.STRING_512;
 import static io.spine.util.Exceptions.newIllegalArgumentException;
 import static java.util.Objects.requireNonNull;
@@ -285,9 +286,25 @@ public abstract class IdColumn<I> {
             return id;
         }
 
+        /**
+         * Returns {@code String}-related SQL type if the wrapped column specifies one by itself.
+         *
+         * <p>Returns {@link Type#STRING_512 STRING_512} if own column SQL type is for some reason
+         * not a {@code String}-related one.
+         *
+         * @implNote It's unlikely that users choose to create a {@code StringIdColumn}
+         *         on top of a non-{@code String} column, but just in case
+         *         Spine returns the widest {@code String}-related SQL type,
+         *         so that such column values could be successfully serialized
+         *         into the native table column.
+         */
         @Override
         public Type sqlType() {
-            return column().type() == STRING ? STRING : STRING_512;
+            Type type = column().type();
+            if(type == STRING || type == STRING_255 || type == STRING_512) {
+                return type;
+            }
+            return STRING_512;
         }
 
         @Override

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/query/IdColumn.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/query/IdColumn.java
@@ -70,8 +70,8 @@ public abstract class IdColumn<I> {
      *
      * <p>The column should have a valid SQL type.
      *
-     * <p>This also implies that actual ID values will be primitive and matching to the column SQL
-     * type.
+     * <p>This also implies that actual ID values will be primitive
+     * and matching to the column SQL type.
      *
      * @see #of(TableColumn, Class) for {@link Message}-type ID column creation
      * @see #ofEntityClass(TableColumn, Class) for {@link Entity} ID column creation
@@ -137,8 +137,8 @@ public abstract class IdColumn<I> {
         checkNotNull(column);
         checkNotNull(entityClass);
         checkArgument(column.type() == null,
-                      "Entity ID type is calculated at runtime and shouldn't have an SQL type " +
-                      "pre-set");
+                      "Entity ID type is calculated at runtime " +
+                              "and shouldn't have an SQL type pre-set");
         Class<?> idClass = asEntityClass(entityClass).idClass();
         if (idClass == Long.class) {
             return  (IdColumn<I>) new LongIdColumn(column);

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/query/IdColumn.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/query/IdColumn.java
@@ -43,8 +43,9 @@ import static io.spine.server.entity.model.EntityClass.asEntityClass;
 import static io.spine.server.storage.jdbc.Type.INT;
 import static io.spine.server.storage.jdbc.Type.LONG;
 import static io.spine.server.storage.jdbc.Type.STRING;
-import static io.spine.server.storage.jdbc.Type.STRING_255;
+import static io.spine.server.storage.jdbc.Type.STRING_512;
 import static io.spine.util.Exceptions.newIllegalArgumentException;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A wrapper for the column which stores a primary key in a DB {@linkplain AbstractTable table}.
@@ -78,7 +79,7 @@ public abstract class IdColumn<I> {
     @SuppressWarnings("unchecked") // It's up to caller to keep the ID class and SQL type in sync.
     public static <I> IdColumn<I> of(TableColumn column) {
         checkNotNull(column);
-        Type type = checkNotNull(column.type(),
+        Type type = requireNonNull(column.type(),
                                  "Please use other suitable method overload if ID column SQL " +
                                  "type is unknown at compile time");
         switch (type) {
@@ -87,6 +88,7 @@ public abstract class IdColumn<I> {
             case LONG:
                 return (IdColumn<I>) new LongIdColumn(column);
             case STRING_255:
+            case STRING_512:
             case STRING:
                 return (IdColumn<I>) new StringIdColumn(column);
             case BOOLEAN:
@@ -285,7 +287,7 @@ public abstract class IdColumn<I> {
 
         @Override
         public Type sqlType() {
-            return column().type() == STRING ? STRING : STRING_255;
+            return column().type() == STRING ? STRING : STRING_512;
         }
 
         @Override
@@ -316,7 +318,7 @@ public abstract class IdColumn<I> {
 
         @Override
         public Type sqlType() {
-            return STRING_255;
+            return STRING_512;
         }
 
         @Override

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/Column.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/Column.java
@@ -32,7 +32,7 @@ import io.spine.server.storage.jdbc.query.IdColumn;
 
 import javax.annotation.Nullable;
 
-import static io.spine.server.storage.jdbc.Type.STRING_255;
+import static io.spine.server.storage.jdbc.Type.STRING_512;
 
 public final class Column {
 
@@ -55,7 +55,7 @@ public final class Column {
     private enum GivenIdColumn implements TableColumn {
 
         ID(null),
-        STRING(STRING_255);
+        STRING(STRING_512);
 
         @Nullable
         private final Type type;

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/IdColumnTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/IdColumnTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.spine.server.storage.jdbc.Type.INT;
 import static io.spine.server.storage.jdbc.Type.LONG;
-import static io.spine.server.storage.jdbc.Type.STRING_255;
+import static io.spine.server.storage.jdbc.Type.STRING_512;
 import static io.spine.server.storage.jdbc.given.Column.idTableColumn;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -65,7 +65,7 @@ class IdColumnTest {
     @DisplayName("have `varchar255` implementation")
     void haveStringImpl() {
         IdColumn<?> column = IdColumn.ofEntityClass(idTableColumn(), StringIdEntity.class);
-        assertEquals(STRING_255, column.sqlType());
+        assertEquals(STRING_512, column.sqlType());
         assertSame(String.class, column.javaType());
     }
 
@@ -73,7 +73,7 @@ class IdColumnTest {
     @DisplayName("cast message IDs to string")
     void castMessageIdsToString() {
         IdColumn<?> column = IdColumn.ofEntityClass(idTableColumn(), MessageIdEntity.class);
-        assertEquals(STRING_255, column.sqlType());
+        assertEquals(STRING_512, column.sqlType());
         assertTrue(Message.class.isAssignableFrom(column.javaType()));
     }
 

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/query/IdColumnTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/query/IdColumnTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("IdColumn should")
+@DisplayName("`IdColumn` should")
 class IdColumnTest {
 
     @Test
@@ -62,7 +62,7 @@ class IdColumnTest {
     }
 
     @Test
-    @DisplayName("have `varchar255` implementation")
+    @DisplayName("have `VARCHAR(512)` implementation")
     void haveStringImpl() {
         IdColumn<?> column = IdColumn.ofEntityClass(idTableColumn(), StringIdEntity.class);
         assertEquals(STRING_512, column.sqlType());

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 
 val spineCoreVersion by extra("1.9.0-SNAPSHOT.10")
 val spineBaseVersion by extra("1.9.0-SNAPSHOT.5")
-val versionToPublish by extra("1.9.0-SNAPSHOT.3")
+val versionToPublish by extra("1.9.0-SNAPSHOT.4")


### PR DESCRIPTION
This changeset addresses #164.

As of this PR, `VARCHAR(512)` will be used to store identifiers (turned into strings) for all known Spine-specific tables.

The library version is set to `1.9.0-SNAPSHOT.4`.