### PR TITLE
Add MySQL regression test for long identifiers (#164)

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,8 +34,8 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.400"
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.400"
+    const val version = "2.0.0-SNAPSHOT.402"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.402"
 
     const val lib = "$group:tool-base:$version"
     const val classicCodegen = "$group:classic-codegen:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/Testcontainers.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/Testcontainers.kt
@@ -26,12 +26,35 @@
 
 package io.spine.dependency.test
 
-// https://github.com/testcontainers/testcontainers-java
+/**
+ * Testcontainers for Java — provides throwaway, lightweight instances of databases and other
+ * services running in Docker containers.
+ *
+ * The MySQL-based storage tests use it to run against a real MySQL server.
+ *
+ * The [mySql] and [junitJupiter] modules are released together with the [core][lib] artifact.
+ * The version below is the latest one for which all three modules are published.
+ *
+ * @see <a href="https://github.com/testcontainers/testcontainers-java">
+ *     Testcontainers for Java at GitHub</a>
+ */
 @Suppress("unused", "ConstPropertyName")
 object Testcontainers {
     private const val version = "1.21.4"
     private const val group = "org.testcontainers"
+
+    /**
+     * The core Testcontainers library.
+     */
     const val lib = "$group:testcontainers:$version"
+
+    /**
+     * The JUnit 5 (Jupiter) integration.
+     */
     const val junitJupiter = "$group:junit-jupiter:$version"
-    const val gcloud = "$group:gcloud:$version"
+
+    /**
+     * The MySQL container support.
+     */
+    const val mySql = "$group:mysql:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/Testcontainers.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/Testcontainers.kt
@@ -26,35 +26,12 @@
 
 package io.spine.dependency.test
 
-/**
- * Testcontainers for Java — provides throwaway, lightweight instances of databases and other
- * services running in Docker containers.
- *
- * The MySQL-based storage tests use it to run against a real MySQL server.
- *
- * The [mySql] and [junitJupiter] modules are released together with the [core][lib] artifact.
- * The version below is the latest one for which all three modules are published.
- *
- * @see <a href="https://github.com/testcontainers/testcontainers-java">
- *     Testcontainers for Java at GitHub</a>
- */
+// https://github.com/testcontainers/testcontainers-java
 @Suppress("unused", "ConstPropertyName")
 object Testcontainers {
     private const val version = "1.21.4"
     private const val group = "org.testcontainers"
-
-    /**
-     * The core Testcontainers library.
-     */
     const val lib = "$group:testcontainers:$version"
-
-    /**
-     * The JUnit 5 (Jupiter) integration.
-     */
     const val junitJupiter = "$group:junit-jupiter:$version"
-
-    /**
-     * The MySQL container support.
-     */
-    const val mySql = "$group:mysql:$version"
+    const val gcloud = "$group:gcloud:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/IncrementGuard.kt
@@ -28,14 +28,21 @@
 
 package io.spine.gradle.publish
 
+import io.spine.gradle.Build
 import io.spine.gradle.SpineTaskGroup
+import io.spine.gradle.base.check
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.publish.maven.tasks.PublishToMavenLocal
 
 /**
- * Gradle plugin that adds a [CheckVersionIncrement] task.
+ * Gradle plugin that adds a [CheckVersionIncrement] task verifying that the
+ * project version was incremented before its artifacts are published.
  *
- * The task is called `checkVersionIncrement` inserted before the `check` task.
+ * The task — named `checkVersionIncrement` — runs before the `check` task and
+ * before any `publishToMavenLocal` task. It actually executes only when the
+ * verification is meaningful; see [apply].
  */
 class IncrementGuard : Plugin<Project> {
 
@@ -57,39 +64,84 @@ class IncrementGuard : Plugin<Project> {
             }
             return baseBranch.endsWith("master") || baseBranch.endsWith("main")
         }
+
+        /**
+         * Tells whether the [CheckVersionIncrement] action must actually run for
+         * the current build.
+         *
+         * The increment is verified in two situations:
+         *  1. [ciPullRequest] — a CI pull request that must check the version
+         *     (see [shouldCheckVersion]); or
+         *  2. a local build (not [onCi]) that is going to publish to Maven Local
+         *     ([localPublish]).
+         *
+         * CI pushes and tag builds that publish to Maven Local — e.g. to feed
+         * integration tests — deliberately skip the check, so that re-publishing
+         * an already released version does not fail them.
+         */
+        internal fun mustVerify(
+            ciPullRequest: Boolean,
+            onCi: Boolean,
+            localPublish: Boolean,
+        ): Boolean = ciPullRequest || (!onCi && localPublish)
+
+        /**
+         * Tells whether [tasks] contains a Maven Local publishing task that
+         * belongs to the given [project].
+         *
+         * The scan is limited to [project]'s own publications so that, in a
+         * multi-project build, a sibling module's `publishToMavenLocal` does not
+         * trigger this module's check — which would verify an unrelated version.
+         */
+        internal fun localPublishPlanned(tasks: Iterable<Task>, project: Project): Boolean =
+            tasks.any { it is PublishToMavenLocal && it.project == project }
     }
 
     /**
-     * Adds the [CheckVersionIncrement] task to the project.
+     * Adds the [CheckVersionIncrement] task to the [target] project and wires it
+     * into two execution paths:
      *
-     * The task is created anyway, but it is enabled only if:
-     *  1. The project is built on GitHub CI, and
-     *  2. The job is a pull request targeting a default (`master` or `main`) or
-     *     a release-line (e.g. `2.x-jdk8-master`) branch.
+     *  1. The `check` task depends on it, so that CI pull requests verify
+     *     the increment.
+     *  2. Every `publishToMavenLocal` task depends on it, so that a local publish —
+     *     used by integration tests that consume artifacts from `~/.m2` — cannot
+     *     overwrite an already published version.
+     *
+     * The task is always created and wired, but its action runs only when:
+     *  1. the build is a GitHub Actions pull request targeting a default
+     *     (`master` or `main`) or a release-line (e.g. `2.x-jdk8-master`) branch; or
+     *  2. the build runs locally (outside CI) and is going to publish artifacts
+     *     to Maven Local.
      *
      * It is the responsibility of a branch that aims to merge into a default
      * (or otherwise protected) branch to bump the version. Auxiliary branches do not
      * deal with the versions in the release cycle, so pull requests targeting them,
-     * direct pushes, and tag builds do not run the check. This also prevents unexpected
-     * CI fails when re-building `master` multiple times, creating git tags, and in other
-     * cases that go outside the "usual" development cycle.
+     * direct pushes, and tag builds do not run the check. In particular, the
+     * Maven Local guard is restricted to local builds: re-building `master`,
+     * creating git tags, and other CI jobs that publish locally (e.g. to feed
+     * integration tests) keep succeeding even though their version is already
+     * published. Ordinary local builds that do not publish stay free from the
+     * network-bound version check as well.
      */
     override fun apply(target: Project) {
         val tasks = target.tasks
-        tasks.register(taskName, CheckVersionIncrement::class.java) {
+        val checkVersion = tasks.register(taskName, CheckVersionIncrement::class.java) {
             group = SpineTaskGroup.name
             description = "Verifies that the project version was incremented before publishing"
             repository = CloudArtifactRegistry.repository
-            tasks.getByName("check").dependsOn(this)
-
-            if (!shouldCheckVersion()) {
-                logger.info(
-                    "The build does not represent a GitHub Actions pull request job " +
-                            "targeting a default or a release-line branch, " +
-                            "the `checkVersionIncrement` task is disabled."
-                )
-                this.enabled = false
+            onlyIf {
+                mustVerify(shouldCheckVersion(), Build.ci, it.publishesToMavenLocal())
             }
+        }
+
+        // Verify the increment on CI pull requests via the `check` lifecycle task.
+        tasks.check.configure { dependsOn(checkVersion) }
+
+        // Verify it before publishing to Maven Local too: integration tests in this
+        // and sibling projects consume the freshly published artifacts from `~/.m2`,
+        // so a non-incremented version would let them pick up a stale artifact.
+        tasks.withType(PublishToMavenLocal::class.java).configureEach {
+            dependsOn(checkVersion)
         }
     }
 
@@ -110,3 +162,20 @@ class IncrementGuard : Plugin<Project> {
         return shouldCheckVersion(event, baseBranch)
     }
 }
+
+/**
+ * Tells whether the current build is going to publish this task's project to
+ * Maven Local.
+ *
+ * Integration tests in this and sibling projects consume freshly built artifacts
+ * from `~/.m2`. Publishing them under a version that already exists would let those
+ * tests pick up a stale artifact, so the version increment must be verified before
+ * any local publication runs.
+ *
+ * Only this task's own project is considered: a sibling module's local publish in
+ * the same invocation must not trigger this module's check. The predicate is
+ * evaluated lazily as a task `onlyIf` spec, by which point the execution
+ * [task graph][org.gradle.api.execution.TaskExecutionGraph] is fully populated.
+ */
+private fun Task.publishesToMavenLocal(): Boolean =
+    IncrementGuard.localPublishPlanned(project.gradle.taskGraph.allTasks, project)

--- a/buildSrc/src/test/kotlin/io/spine/gradle/publish/IncrementGuardTest.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/publish/IncrementGuardTest.kt
@@ -26,8 +26,15 @@
 
 package io.spine.gradle.publish
 
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
+import io.spine.gradle.publish.IncrementGuard.Companion.localPublishPlanned
+import io.spine.gradle.publish.IncrementGuard.Companion.mustVerify
 import io.spine.gradle.publish.IncrementGuard.Companion.shouldCheckVersion
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.publish.maven.tasks.PublishToMavenLocal
+import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -76,4 +83,103 @@ class IncrementGuardTest {
             shouldCheckVersion(null, null) shouldBe false
         }
     }
+
+    @Nested
+    inner class `actually run the check` {
+
+        @Test
+        fun `on a CI pull request to a protected branch`() {
+            mustVerify(ciPullRequest = true, onCi = true, localPublish = false) shouldBe true
+        }
+
+        @Test
+        fun `on a local build that publishes to Maven Local`() {
+            mustVerify(ciPullRequest = false, onCi = false, localPublish = true) shouldBe true
+        }
+    }
+
+    @Nested
+    inner class `skip the check` {
+
+        @Test
+        fun `on a local build that does not publish`() {
+            mustVerify(ciPullRequest = false, onCi = false, localPublish = false) shouldBe false
+        }
+
+        @Test
+        fun `on a CI build that publishes to Maven Local outside a protected-branch PR`() {
+            // E.g. a push to `master` or a tag build running integration tests: the
+            // version is already published, so re-verifying it would fail the build.
+            mustVerify(ciPullRequest = false, onCi = true, localPublish = true) shouldBe false
+        }
+    }
+
+    @Nested
+    inner class `detect a Maven Local publish` {
+
+        @Test
+        fun `for the task's own project`() {
+            val project = guardedProject()
+            val publish = project.tasks
+                .register("publishFooPublicationToMavenLocal", PublishToMavenLocal::class.java)
+                .get()
+
+            localPublishPlanned(listOf(publish), project) shouldBe true
+        }
+
+        @Test
+        fun `but not when only a sibling project publishes`() {
+            val root = ProjectBuilder.builder().build()
+            val lib = ProjectBuilder.builder().withParent(root).withName("lib").build()
+            val app = ProjectBuilder.builder().withParent(root).withName("app").build()
+            app.pluginManager.apply("maven-publish")
+            val appPublish = app.tasks
+                .register("publishFooPublicationToMavenLocal", PublishToMavenLocal::class.java)
+                .get()
+
+            localPublishPlanned(listOf(appPublish), lib) shouldBe false
+        }
+    }
+
+    @Nested
+    inner class `make 'checkVersionIncrement' a dependency of` {
+
+        @Test
+        fun `the 'check' task`() {
+            val project = guardedProject()
+            val check = project.tasks.getByName("check")
+
+            check.dependencyNames() shouldContain IncrementGuard.taskName
+        }
+
+        @Test
+        fun `every Maven Local publishing task`() {
+            val project = guardedProject()
+            val localPublish = project.tasks.register(
+                "publishFooPublicationToMavenLocal",
+                PublishToMavenLocal::class.java
+            ).get()
+
+            localPublish.dependencyNames() shouldContain IncrementGuard.taskName
+        }
+    }
 }
+
+/**
+ * Creates a project with the `base` plugin (for the `check` task), the
+ * `maven-publish` plugin (for [PublishToMavenLocal] tasks), and [IncrementGuard]
+ * applied.
+ */
+private fun guardedProject(): Project {
+    val project = ProjectBuilder.builder().build()
+    project.pluginManager.apply("base")
+    project.pluginManager.apply("maven-publish")
+    project.pluginManager.apply(IncrementGuard::class.java)
+    return project
+}
+
+/**
+ * Obtains the names of the tasks this task directly depends on.
+ */
+private fun Task.dependencyNames(): Set<String> =
+    taskDependencies.getDependencies(this).map { it.name }.toSet()

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-rdbms:2.0.0-SNAPSHOT.102`
+# Dependencies of `io.spine:spine-rdbms:2.0.0-SNAPSHOT.103`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1131,6 +1131,6 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 24 18:56:02 WEST 2026** using 
+This report was generated on **Fri Jun 26 17:45:33 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>jdbc-storage</artifactId>
-<version>2.0.0-SNAPSHOT.102</version>
+<version>2.0.0-SNAPSHOT.103</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/rdbms/src/test/kotlin/io/spine/server/storage/jdbc/mysql/MysqlLongIdSpec.kt
+++ b/rdbms/src/test/kotlin/io/spine/server/storage/jdbc/mysql/MysqlLongIdSpec.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.jdbc.mysql
+
+import com.google.protobuf.StringValue
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+import io.spine.server.storage.RecordSpec
+import io.spine.server.storage.Storage
+import io.spine.server.storage.jdbc.given.JdbcStorageFactoryTestEnv.singleTenantSpec
+import io.spine.test.storage.StgProject
+import io.spine.test.storage.StgProjectId
+import io.spine.test.storage.stgProject
+import io.spine.test.storage.stgProjectId
+import io.spine.testing.SlowTest
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * A regression test for [issue #164](https://github.com/SpineEventEngine/jdbc-storage/issues/164).
+ *
+ * The ID column used to be `VARCHAR(255)`, so storing a record whose (possibly serialized)
+ * identifier was longer than 255 characters failed on MySQL with a `MysqlDataTruncation`
+ * ("Data too long for column") error. The ID column is now `VARCHAR(512)`, both for plain
+ * `String` identifiers and for message identifiers serialized to JSON.
+ *
+ * These tests run against a real MySQL server, reproducing the original failure environment.
+ */
+@DisplayName(
+    "`JdbcRecordStorage` on MySQL should store a record whose identifier exceeds 255 characters"
+)
+@SlowTest
+@EnableConditionally
+internal class MysqlLongIdSpec {
+
+    @Test
+    fun `when the identifier is a 'String'`() {
+        val factory = MysqlTests.newFactory()
+        val spec = RecordSpec(
+            String::class.java,
+            StringValue::class.java,
+            StringValue::getValue
+        )
+        val storage: Storage<String, StringValue> =
+            factory.createRecordStorage(singleTenantSpec(), spec)
+
+        val longId = "i".repeat(LONG_ID_LENGTH)
+        val record = StringValue.of(longId)
+
+        storage.write(longId, record)
+
+        val stored = storage.read(longId).shouldBePresent()
+        stored shouldBe record
+    }
+
+    @Test
+    fun `when the identifier is a message serialized to a long 'String'`() {
+        val factory = MysqlTests.newFactory()
+        val spec = RecordSpec(
+            StgProjectId::class.java,
+            StgProject::class.java,
+            StgProject::getId
+        )
+        val storage: Storage<StgProjectId, StgProject> =
+            factory.createRecordStorage(singleTenantSpec(), spec)
+
+        val projectId = stgProjectId { id = "i".repeat(LONG_ID_LENGTH) }
+        val project = stgProject {
+            id = projectId
+            name = "A project with a long identifier"
+        }
+
+        storage.write(projectId, project)
+
+        val stored = storage.read(projectId).shouldBePresent()
+        stored shouldBe project
+    }
+
+    companion object {
+
+        /**
+         * The length of the identifiers used in these tests.
+         *
+         * It is well above the former `VARCHAR(255)` limit of the ID column, yet within the
+         * `VARCHAR(512)` width now used, so the identifiers are stored without truncation. The
+         * serialized form of the message identifier is longer still, and so also overflows the
+         * old limit.
+         */
+        private const val LONG_ID_LENGTH = 300
+    }
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of this library.
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.102")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.103")


### PR DESCRIPTION
## Summary

Adds the missing MySQL regression coverage for #164 (*"`INBOX_ID` column type is too narrow"*) and fixes a build break the branch had picked up.

The fix itself already landed on `master` (via #175): every primary-key ID column is now `VARCHAR(512)` (`IdColumn` → `STRING_512`), while all other string/message columns are `TEXT`. This is a more general solution than the 1.x PR #168, which widened specific named per-table columns. This PR locks that behavior in with a test.

## Regression test

`MysqlLongIdSpec` (new, Kotlin) stores records on a **real MySQL server** (Testcontainers) whose identifiers exceed the former `VARCHAR(255)` width, covering both fixed paths:

- a plain `String` identifier (300 chars), and
- a message identifier serialized to JSON.

Both are written and read back intact. It is a genuine guard: reverting either `IdColumn.sqlType()` to `STRING_255` makes both cases fail with the original error from the issue — `MysqlDataTruncation: Data too long for column 'ID'`.

## Build fix

The `Update config` commit had replaced this repo's `Testcontainers` dependency catalog with a variant that dropped `mySql` (still referenced by `rdbms/build.gradle.kts`) and added an unused `gcloud`, breaking the module build with an unresolved reference. The follow-up commit restores it to match `master` — so the two `Testcontainers.kt` commits net to zero in the diff against `master`.

## Also on this branch

Routine maintenance from earlier commits: a `config` submodule update (carrying the `IncrementGuard` rework + `IncrementGuardTest` and a `ToolBase` tweak) and the version bump to `2.0.0-SNAPSHOT.103`.

## Verification

- `MysqlLongIdSpec` on MySQL: **2/2 pass**; with the fix reverted → **2/2 fail** with the issue's truncation error.
- Full `./gradlew build dokkaGenerate` (incl. all MySQL tests via Docker): **BUILD SUCCESSFUL**.

Closes #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)