### PR TITLE
Store MySQL identifiers case-sensitively via binary collation

### DIFF
--- a/.agents/tasks/mysql-case-insensitive-varchar-173.md
+++ b/.agents/tasks/mysql-case-insensitive-varchar-173.md
@@ -1,0 +1,58 @@
+# Case-insensitive `VARCHAR` in MySQL collides with entity IDs (#173)
+
+Issue: https://github.com/SpineEventEngine/jdbc-storage/issues/173
+
+## Problem
+
+MySQL non-binary string types (`VARCHAR`, `TEXT`) use a case- and
+accent-insensitive collation by default. Spine stores entity identifiers and
+`String` columns in `VARCHAR(512)`/`VARCHAR(255)`/`TEXT`, so two distinct
+identifiers that differ only by case — e.g. a username `"name"` vs `"Name"` —
+collide: writes for `"Name"` are routed to the row stored under `"name"`.
+
+PostgreSQL and H2 compare string data case-sensitively by default, so only the
+MySQL mapping is affected.
+
+## Fix
+
+Make the MySQL type mapping emit a binary collation for every character-based
+column type. In `PredefinedMapping.MYSQL_9_7`, override:
+
+- `STRING_255` → `VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin`
+- `STRING_512` → `VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin`
+- `STRING`     → `TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin`
+
+Implemented via a nested `MySql` helper holding the constants, mirroring the
+existing `PostgreSql` helper. The collation lives in the type mapping (its
+documented responsibility), so it flows into `CreateTable` for both the ID
+column and data columns without touching the DDL builder.
+
+`utf8mb4` (not the deprecated `utf8`/`utf8mb3` from the issue example) is used as
+the modern, full-Unicode charset; `utf8mb4_bin` is the binary collation. The
+column byte width is unchanged, so the `VARCHAR(512)` primary key stays within
+InnoDB index limits.
+
+## Verification
+
+- `PredefinedMappingTest`: MySQL string types carry the collation; H2/Postgres
+  do not.
+- `CreateTableSpec`: the generated `CREATE TABLE` carries the collation on the
+  ID column under the MySQL mapping.
+- `MysqlIdCaseSensitivityTest` (Docker-gated): writing records with IDs `"name"`
+  and `"Name"` yields two distinct rows.
+- `docs/type-mapping.md`: table updated + peculiarity documented.
+
+## Test-harness note
+
+`JdbcStorageFactoryTestEnv.newFactory()` ran the **MySQL** mapping over an **in-memory H2**
+database. That worked only because `MYSQL_9_7` and `H2_2_4` produced identical DDL. Once the
+MySQL mapping started emitting `CHARACTER SET utf8mb4 COLLATE utf8mb4_bin`, H2 could no longer
+parse the generated `CREATE TABLE`. Fixed by switching the helper to `H2_2_4` (the mapping that
+matches its data source); behaviour for the H2-backed tests is byte-identical to before.
+
+## Status
+
+Done — `:rdbms:check` green (366 tests, 0 failed; checkstyleMain, detekt, pmdMain pass). The
+Docker-gated `MysqlIdCaseSensitivityTest` was confirmed to fail when the collation override is
+removed, proving it guards the regression. Not committed (awaiting review/authorization).
+

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
+      "Edit(version.gradle.kts)",
       "Bash(./gradlew:*)",
       "Bash(./config/gradlew:*)",
       "Bash(git status:*)",

--- a/.github/workflows/increment-guard.yml
+++ b/.github/workflows/increment-guard.yml
@@ -1,5 +1,9 @@
-# Ensures that the current lib version is not yet published by executing the Gradle
-# `checkVersionIncrement` task.
+# Guards the project version by executing the Gradle `checkVersionIncrement` task,
+# which verifies that the version is both (a) strictly greater than the base branch
+# version in `version.gradle.kts` and (b) not already published. The result is
+# published as the `Version Guard` commit status — the context required by branch
+# protection and re-published by `revalidate-versions.yml` on the heads of other open
+# PRs when the base branch advances (so a stale duplicate bump turns red before merge).
 #
 # The check runs only for pull requests targeting a default (`master`/`main`) or
 # a release-line (e.g. `2.x-jdk8-master`) branch. It is the responsibility of a branch
@@ -15,18 +19,44 @@ name: Version Guard
 
 on:
   pull_request:
+    # Beyond the default activity types (`opened`, `synchronize`, `reopened`), two more are
+    # needed because they change what the guard must compare against without a new head SHA,
+    # which would otherwise leave a stale-green `Version Guard` status mergeable:
+    #   * `ready_for_review` — a draft that went stale while in draft becomes ready; and
+    #   * `edited` — the base branch is retargeted (e.g. a release line -> `master`), so the
+    #     strict comparison must be recomputed against the new base.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
 
 jobs:
   check:
     name: Check version increment
     runs-on: ubuntu-latest
-    # Default and release-line branches, e.g. `master`, `main`, `2.x-jdk8-master`.
-    if: endsWith(github.base_ref, 'master') || endsWith(github.base_ref, 'main')
+    # Default and release-line branches, e.g. `master`, `main`, `2.x-jdk8-master`. For an
+    # `edited` event, run only when the base actually changed (a retarget carries
+    # `changes.base.ref.from`); title/body edits carry no `changes.base` and are skipped, so
+    # the guard is not rebuilt needlessly.
+    if: >-
+      (endsWith(github.base_ref, 'master') || endsWith(github.base_ref, 'main'))
+      && (github.event.action != 'edited' || github.event.changes.base.ref.from != '')
+
+    # `statuses: write` lets the job publish the `Version Guard` commit status that
+    # branch protection requires.
+    permissions:
+      contents: read
+      statuses: write
 
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: 'true'
+
+      # `checkVersionIncrement` reads `origin/<base>:version.gradle.kts`. The pull request
+      # checkout does not include the base branch, so fetch its tip into the expected ref.
+      - name: Fetch the base branch
+        shell: bash
+        run: |
+          git fetch --no-tags --depth=1 \
+            origin "+refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
 
       - uses: actions/setup-java@v5
         with:
@@ -35,6 +65,36 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v6
 
-      - name: Check version is not yet published
+      - name: Check version increment
+        id: guard
         shell: bash
+        # `VERSION_GUARD` enables the strict base-branch comparison in `checkVersionIncrement`.
+        # Only this workflow fetches the base ref (the step above), so the comparison is gated
+        # to it: other CI builds pull the task in via `publishToMavenLocal` on a shallow
+        # checkout and must not attempt to read `origin/<base>`.
+        env:
+          VERSION_GUARD: "true"
         run: ./gradlew checkVersionIncrement --stacktrace
+
+      # Publish the verdict as the `Version Guard` commit status on the PR head. Posting it
+      # on every run (success or failure) is what lets a later re-bump clear a failure that
+      # `revalidate-versions.yml` set when the base branch advanced.
+      #
+      # Skipped for fork PRs: `GITHUB_TOKEN` is read-only for them, so the status cannot be
+      # posted (and a fork head SHA is not in this repo). The Spine agent workflow pushes PR
+      # branches to the same repository; fork contributions are handled by a maintainer, who
+      # owns the version bump.
+      - name: Report the Version Guard status
+        if: always() && github.event.pull_request.head.repo.fork == false
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          state=failure
+          if [ "${{ steps.guard.outcome }}" = "success" ]; then
+            state=success
+          fi
+          gh api -X POST "repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+            -f state="${state}" \
+            -f context="Version Guard" \
+            -f description="Version increment check"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,3 +64,18 @@ jobs:
           REPO_SLUG: ${{ github.repository }}    # e.g. SpineEventEngine/core-jvm
           GOOGLE_APPLICATION_CREDENTIALS: ./maven-publisher.json
           NPM_TOKEN: ${{ secrets.NPM_SECRET }}
+
+      # A failed publication on `master` is most often a version collision: a stale
+      # duplicate bump merged before `revalidate-versions.yml` could turn it red (the
+      # narrow auto-merge race). The artifact is safe — the registry rejects the
+      # overwrite — but the fix needs a human/agent, so make the failure loud and
+      # actionable instead of a quiet red run.
+      - name: Report a failed publication
+        if: failure()
+        shell: bash
+        run: |
+          echo "::error title=Publish failed::Publishing to Maven failed on the base branch. If this is a version collision, the version is already published (immutable). Bump 'version.gradle.kts' on the base branch (e.g. via a small PR) and re-run this workflow."
+          echo "Publish failed. If the cause is a version collision:"
+          echo "  1. Bump 'version.gradle.kts' on the base branch to the next free version."
+          echo "  2. Re-run this 'Publish' workflow."
+          echo "Stale duplicate bumps are normally caught before merge by 'revalidate-versions.yml'."

--- a/.github/workflows/revalidate-versions.yml
+++ b/.github/workflows/revalidate-versions.yml
@@ -1,0 +1,57 @@
+# Re-judges every other open pull request when the base branch advances.
+#
+# Publishing runs on every push to a release base branch, so once one pull request merges
+# and bumps the version, any other open PR that bumped to the same (or a lower) value is
+# now stale: its publish would collide. GitHub does not re-run a PR's checks when its base
+# advances, so this workflow does it actively — for each other open PR whose
+# `version.gradle.kts` version is `<=` the new base version, it posts a failing
+# `Version Guard` commit status on the PR head, blocking the merge until the author
+# re-bumps. The status self-clears: the re-bump push runs `increment-guard.yml`, which
+# posts a fresh `success` on the new head.
+#
+# This narrows, but does not close, the race against auto-merge. A PR that is already
+# mergeable can merge in the seconds before this fan-out marks it stale; that late merge
+# produces a publish collision which the immutable Maven registry rejects (a loud,
+# recoverable red Publish), never an overwrite. The deterministic guarantee is the
+# registry's immutability, not this signal.
+
+name: Revalidate Versions
+
+on:
+  push:
+    # Matches the PR guard's `endsWith(base_ref, 'master'|'main')` and the same scope as
+    # `build-on-ubuntu.yml`. `**` (unlike `*`) also crosses `/`, so slash-named release
+    # lines such as `release/2.x-master` are covered. Keeping these definitions identical
+    # ensures every branch guarded on the PR side is also revalidated here.
+    branches:
+      - '**master'
+      - '**main'
+
+permissions:
+  contents: read
+  statuses: write
+  pull-requests: read
+
+concurrency:
+  # Only the newest tip of a given base matters; a later push to the same ref cancels an
+  # in-flight fan-out for it. Different bases run independently.
+  group: revalidate-versions-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  revalidate:
+    name: Revalidate open PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+
+      - name: Revalidate open PRs against the new base version
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BASE_REF: ${{ github.ref_name }}
+        # Invoked via `bash` so it does not depend on the script's committed executable bit.
+        run: bash ./config/scripts/revalidate-versions.sh

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,8 +34,8 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.401"
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.401"
+    const val version = "2.0.0-SNAPSHOT.402"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.402"
 
     const val lib = "$group:tool-base:$version"
     const val classicCodegen = "$group:classic-codegen:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,8 +34,8 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.402"
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.402"
+    const val version = "2.0.0-SNAPSHOT.401"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.401"
 
     const val lib = "$group:tool-base:$version"
     const val classicCodegen = "$group:classic-codegen:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/storage/Hikari.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/storage/Hikari.kt
@@ -35,6 +35,6 @@ package io.spine.dependency.storage
  */
 @Suppress("unused", "ConstPropertyName")
 object Hikari {
-    private const val version = "5.0.1"
+    private const val version = "7.1.0"
     const val lib = "com.zaxxer:HikariCP:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/storage/Hikari.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/storage/Hikari.kt
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.lib
+package io.spine.dependency.storage
 
 /**
  * HikariCP — a fast, lightweight JDBC connection pool.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/storage/PostgreSql.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/storage/PostgreSql.kt
@@ -35,6 +35,6 @@ package io.spine.dependency.storage
  */
 @Suppress("unused", "ConstPropertyName")
 object PostgreSql {
-    private const val version = "42.7.4"
+    private const val version = "42.7.11"
     const val connector = "org.postgresql:postgresql:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/storage/PostgreSql.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/storage/PostgreSql.kt
@@ -24,42 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.test
+package io.spine.dependency.storage
 
 /**
- * Testcontainers for Java — provides throwaway, lightweight instances of databases and other
- * services running in Docker containers.
+ * The PostgreSQL JDBC driver (pgJDBC).
  *
- * The MySQL- and PostgreSQL-based storage tests use it to run against a real database server.
+ * Used by the PostgreSQL-based storage tests to connect to a real PostgreSQL server.
  *
- * The [mySql], [postgresql], and [junitJupiter] modules are released together with the
- * [core][lib] artifact. The version below is the latest one for which all modules are published.
- *
- * @see <a href="https://github.com/testcontainers/testcontainers-java">
- *     Testcontainers for Java at GitHub</a>
+ * @see <a href="https://github.com/pgjdbc/pgjdbc">PostgreSQL JDBC Driver at GitHub</a>
  */
 @Suppress("unused", "ConstPropertyName")
-object Testcontainers {
-    private const val version = "1.21.4"
-    private const val group = "org.testcontainers"
-
-    /**
-     * The core Testcontainers library.
-     */
-    const val lib = "$group:testcontainers:$version"
-
-    /**
-     * The JUnit 5 (Jupiter) integration.
-     */
-    const val junitJupiter = "$group:junit-jupiter:$version"
-
-    /**
-     * The MySQL container support.
-     */
-    const val mySql = "$group:mysql:$version"
-
-    /**
-     * The PostgreSQL container support.
-     */
-    const val postgresql = "$group:postgresql:$version"
+object PostgreSql {
+    private const val version = "42.7.4"
+    const val connector = "org.postgresql:postgresql:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/storage/QueryDsl.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/storage/QueryDsl.kt
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.lib
+package io.spine.dependency.storage
 
 /**
  * QueryDSL — a framework for constructing type-safe SQL-like queries in Java.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/Testcontainers.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/Testcontainers.kt
@@ -26,12 +26,35 @@
 
 package io.spine.dependency.test
 
-// https://github.com/testcontainers/testcontainers-java
+/**
+ * Testcontainers for Java — provides throwaway, lightweight instances of databases and other
+ * services running in Docker containers.
+ *
+ * The MySQL-based storage tests use it to run against a real MySQL server.
+ *
+ * The [mySql] and [junitJupiter] modules are released together with the [core][lib] artifact.
+ * The version below is the latest one for which all three modules are published.
+ *
+ * @see <a href="https://github.com/testcontainers/testcontainers-java">
+ *     Testcontainers for Java at GitHub</a>
+ */
 @Suppress("unused", "ConstPropertyName")
 object Testcontainers {
     private const val version = "1.21.4"
     private const val group = "org.testcontainers"
+
+    /**
+     * The core Testcontainers library.
+     */
     const val lib = "$group:testcontainers:$version"
+
+    /**
+     * The JUnit 5 (Jupiter) integration.
+     */
     const val junitJupiter = "$group:junit-jupiter:$version"
-    const val gcloud = "$group:gcloud:$version"
+
+    /**
+     * The MySQL container support.
+     */
+    const val mySql = "$group:mysql:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/VersionComparator.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/VersionComparator.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle
+
+/**
+ * Compares dependency version strings by their meaning rather than lexicographically.
+ *
+ * Numeric segments are ordered as numbers, so `10.0.0` is newer than `9.2.0`, and
+ * `2.0.0-SNAPSHOT.100` is newer than `2.0.0-SNAPSHOT.99`. A plain `String` comparison
+ * would order both pairs the other way around.
+ *
+ * The rules follow Semantic Versioning where it applies:
+ *
+ *  1. A version consists of a release part and an optional qualifier, separated by
+ *     the first `-`: for `2.0.0-SNAPSHOT.100` these are `2.0.0` and `SNAPSHOT.100`.
+ *  2. Both parts are compared segment by segment, as split by `.`, and also by `-`
+ *     within a qualifier. Two numeric segments are compared as numbers, two textual
+ *     ones as case-insensitive text, and a numeric segment is older than a textual one.
+ *  3. When one version runs out of segments, it is the older one: `1.0.1` is newer
+ *     than `1.0`, and `1.0.0-RC.1` is newer than `1.0.0-RC`.
+ *  4. When the release parts are equal, a version without a qualifier is newer than
+ *     a version with one: `2.0.0` is newer than `2.0.0-SNAPSHOT.100`.
+ *
+ * Unlike full Maven semantics, qualifiers carry no special meaning: `RC`, `SNAPSHOT`,
+ * and the like are ordered as plain text. This keeps the comparison simple and
+ * predictable for the report, where only the relative recency of the versions
+ * of the same artifact matters.
+ */
+internal object VersionComparator : Comparator<String> {
+
+    override fun compare(left: String, right: String): Int {
+        val (leftRelease, leftQualifier) = left.parse()
+        val (rightRelease, rightQualifier) = right.parse()
+        val byRelease = compareSegments(leftRelease, rightRelease)
+        if (byRelease != 0) {
+            return byRelease
+        }
+        return when {
+            leftQualifier == null && rightQualifier == null -> 0
+            leftQualifier == null -> 1
+            rightQualifier == null -> -1
+            else -> compareSegments(leftQualifier, rightQualifier)
+        }
+    }
+
+    /**
+     * Splits this version into the segments of its release part and the segments
+     * of its qualifier, the latter being `null` when the version has no qualifier.
+     */
+    private fun String.parse(): Pair<List<String>, List<String>?> {
+        val release = substringBefore('-')
+        val qualifier = if ('-' in this) substringAfter('-') else null
+        return release.split('.') to qualifier?.split('.', '-')
+    }
+
+    private fun compareSegments(left: List<String>, right: List<String>): Int {
+        for (index in 0 until maxOf(left.size, right.size)) {
+            val bySegment = compareSegment(
+                left.getOrElse(index) { "" },
+                right.getOrElse(index) { "" }
+            )
+            if (bySegment != 0) {
+                return bySegment
+            }
+        }
+        return 0
+    }
+
+    /**
+     * Compares single segments, ordering an absent (empty) segment below any present
+     * one, a numeric segment below a textual one, numbers by their value, and text
+     * case-insensitively.
+     *
+     * Keeping the empty, numeric, and textual segments in distinct buckets makes
+     * the order transitive: comparing a numeric pair as numbers, but a mixed pair
+     * as text, would order `2` < `10` < `1a` < `2`.
+     */
+    private fun compareSegment(left: String, right: String): Int {
+        if (left.isEmpty() || right.isEmpty()) {
+            return left.length.compareTo(right.length)
+        }
+        val leftNumber = left.toLongOrNull()
+        val rightNumber = right.toLongOrNull()
+        return when {
+            leftNumber != null && rightNumber != null -> leftNumber.compareTo(rightNumber)
+            leftNumber != null -> -1
+            rightNumber != null -> 1
+            else -> left.compareTo(right, ignoreCase = true)
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/gradle/VersionGradleFile.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/VersionGradleFile.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle
+
+import java.io.File
+import org.gradle.api.GradleException
+
+/**
+ * Reads a `version.gradle.kts` file and resolves the `extra` properties it declares.
+ *
+ * [contentUnder] and [contentInBase] read the file (from the working tree or a base branch);
+ * [keyForValue] and [valueForKey] resolve its `extra` properties. The following declaration
+ * shapes are handled (see the `bump-version` skill):
+ *
+ *  1. a literal: `val versionToPublish: String by extra("2.0.0-SNAPSHOT.182")`;
+ *  2. an alias to another `extra`: `val versionToPublish by extra(compilerVersion)` paired
+ *     with `val compilerVersion: String by extra("2.0.0-SNAPSHOT.043")`;
+ *  3. an alias to a plain `val`: `val versionToPublish by extra(base)` paired with
+ *     `val base = "2.0.0-SNAPSHOT.043"`.
+ *
+ * The publishing-version property is identified by [keyForValue] using the already-resolved
+ * project version as an oracle, so the specific property name (`versionToPublish`,
+ * `validationVersion`, `compilerVersion`, …) does not need to be hard-coded.
+ *
+ * Only a single alias hop is resolved; an alias to another alias falls through to `null`,
+ * which the caller treats as "publishing version not identified" and skips the check.
+ */
+internal object VersionGradleFile {
+
+    /**
+     * The name of a `version.gradle.kts` file.
+     */
+    const val NAME = "version.gradle.kts"
+
+    private val literalExtra =
+        Regex("""val\s+(\w+)\s*(?::\s*String)?\s+by\s+extra\(\s*"([^"]+)"\s*\)""")
+    private val aliasExtra =
+        Regex("""val\s+(\w+)\s*(?::\s*String)?\s+by\s+extra\(\s*([A-Za-z_]\w*)\s*\)""")
+    private val plainAssignment =
+        Regex("""val\s+(\w+)\s*(?::\s*String)?\s*=\s*"([^"]+)"""")
+
+    /**
+     * Resolves every named `extra` (and the plain `val`s an `extra` may alias) to its
+     * string value.
+     */
+    private fun parse(content: String): Map<String, String> {
+        val literals = literalExtra.findAll(content)
+            .associate { it.groupValues[1] to it.groupValues[2] }
+        val plains = plainAssignment.findAll(content)
+            .associate { it.groupValues[1] to it.groupValues[2] }
+        val resolved = literals.toMutableMap()
+        aliasExtra.findAll(content).forEach { match ->
+            val name = match.groupValues[1]
+            val source = match.groupValues[2]
+            if (name !in resolved) {
+                (literals[source] ?: plains[source])?.let { resolved[name] = it }
+            }
+        }
+        return resolved
+    }
+
+    /**
+     * The name of the property whose resolved value equals [value], or `null` if none does.
+     */
+    fun keyForValue(content: String, value: String): String? =
+        parse(content).entries.firstOrNull { it.value == value }?.key
+
+    /**
+     * The resolved value of the property named [key], or `null` if it is absent.
+     */
+    fun valueForKey(content: String, key: String): String? = parse(content)[key]
+
+    /**
+     * Reads `version.gradle.kts` from [rootDir], or `null` when it is absent.
+     */
+    fun contentUnder(rootDir: File): String? =
+        File(rootDir, NAME).takeIf { it.exists() }?.readText()
+
+    /**
+     * Reads `version.gradle.kts` from the tip of the `origin/<baseRef>` remote-tracking branch.
+     *
+     * Returns `null` when the file does not exist at the base — a newly introduced version file.
+     * Throws a [GradleException] when the base ref cannot be resolved: the Version Guard workflow
+     * is responsible for fetching it, and failing closed surfaces that misconfiguration instead
+     * of silently passing the check.
+     */
+    fun contentInBase(rootDir: File, baseRef: String): String? {
+        val result = gitShow(rootDir, "origin/$baseRef:$NAME")
+        if (result.exitCode == 0) {
+            return result.stdout
+        }
+        // `git show` reports a missing path with these phrasings; everything else
+        // (e.g. an unresolvable ref) is a configuration error we must not swallow.
+        val missingPath = result.stderr.contains("does not exist") ||
+                result.stderr.contains("exists on disk, but not in")
+        if (missingPath) {
+            return null
+        }
+        throw GradleException(
+            "Unable to read `$NAME` from base `origin/$baseRef` " +
+                    "(git exit code ${result.exitCode}): ${result.stderr.trim()}.\n" +
+                    "Ensure the Version Guard workflow fetches the base branch before this check."
+        )
+    }
+}
+
+/**
+ * The outcome of a `git` invocation: its [exitCode] and the captured [stdout] and [stderr].
+ *
+ * @property exitCode The process exit code; `0` on success.
+ * @property stdout The captured standard output stream.
+ * @property stderr The captured standard error stream.
+ */
+private data class GitResult(val exitCode: Int, val stdout: String, val stderr: String)
+
+private fun gitShow(rootDir: File, spec: String): GitResult {
+    // Redirect to files rather than reading the process pipes sequentially: draining
+    // stdout fully before stderr can deadlock if a stream fills its pipe buffer.
+    val outFile = File.createTempFile("git-show", ".out")
+    val errFile = File.createTempFile("git-show", ".err")
+    try {
+        val exitCode = ProcessBuilder("git", "show", spec)
+            .directory(rootDir)
+            .redirectOutput(outFile)
+            .redirectError(errFile)
+            .start()
+            .waitFor()
+        return GitResult(exitCode, outFile.readText(), errFile.readText())
+    } finally {
+        outFile.delete()
+        errFile.delete()
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/CheckVersionIncrement.kt
@@ -26,12 +26,10 @@
 
 package io.spine.gradle.publish
 
-import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
-import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import io.spine.gradle.VersionComparator
+import io.spine.gradle.VersionGradleFile
 import io.spine.gradle.repo.Repository
-import java.io.FileNotFoundException
 import java.net.URI
-import java.net.URL
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
@@ -39,8 +37,20 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 
 /**
- * A task that verifies that the current version of the library has not been published to the given
- * Maven repository yet.
+ * A task that verifies the project version is fit to be published.
+ *
+ * Two independent checks run:
+ *
+ *  1. [checkIncrementedAgainstBase] — inside the dedicated `Version Guard` workflow, the
+ *     project [version] must be strictly greater than the version declared by
+ *     `version.gradle.kts` on the PR's base branch. This is deterministic and
+ *     network-independent: it catches a behavior-changing PR that forgot to bump, and two
+ *     parallel PRs that bumped to the same value, regardless of what is (or is not yet)
+ *     published.
+ *  2. [checkNotPublished] — the [version] must not already exist in the target Maven
+ *     repository, so a publication cannot overwrite an immutable artifact.
+ *
+ * The two checks are complementary; neither subsumes the other.
  */
 open class CheckVersionIncrement : DefaultTask() {
 
@@ -57,7 +67,111 @@ open class CheckVersionIncrement : DefaultTask() {
     val version: String = project.version as String
 
     @TaskAction
-    fun fetchAndCheck() {
+    fun checkVersion() {
+        checkIncrementedAgainstBase()
+        checkNotPublished()
+    }
+
+    /**
+     * Verifies that the project [version] is strictly greater than the version declared by
+     * `version.gradle.kts` on the pull request's base branch.
+     *
+     * The comparison reads the base branch tip with `git show origin/<base>:version.gradle.kts`,
+     * so it runs **only inside the dedicated `Version Guard` workflow** — the one context that
+     * fetches the base ref and signals it via the `VERSION_GUARD` environment variable (see
+     * [IncrementGuard.shouldCompareToBase]). Every other build skips it: a shallow CI checkout
+     * (e.g. the Ubuntu/Windows builds, which pull this task in via `publishToMavenLocal`) has
+     * no base ref to read, and local publishes are not pull requests. Those rely on
+     * [checkNotPublished] instead.
+     *
+     * Within the `Version Guard` workflow, failure modes are deliberately asymmetric:
+     *  - base ref unresolvable — **fail closed** (a workflow misconfiguration must not pass
+     *    silently);
+     *  - `version.gradle.kts` absent on base — treated as a newly introduced file (**pass**);
+     *  - the publishing-version property cannot be identified — **skip** with a warning,
+     *    leaving [checkNotPublished] as the remaining guard, rather than blocking every PR in
+     *    a repository whose `version.gradle.kts` uses an unrecognized shape.
+     */
+    private fun checkIncrementedAgainstBase() {
+        val baseRef = System.getenv("GITHUB_BASE_REF")
+        if (!IncrementGuard.shouldCompareToBase(underVersionGuard(), baseRef)) {
+            logger.info(
+                "Skipping the base-branch increment comparison: it runs only inside the " +
+                    "`Version Guard` workflow, which fetches the base branch. " +
+                    "`checkNotPublished` remains the active guard here."
+            )
+            return
+        }
+        val baseVersion = baseVersionToCompare(
+            checkNotNull(baseRef) { "`shouldCompareToBase` guarantees a non-blank base ref." }
+        )
+        if (baseVersion != null && VersionComparator.compare(version, baseVersion) <= 0) {
+            throw GradleException(
+                """
+                The project version `$version` is not greater than the base branch version
+                `$baseVersion` (base `$baseRef`).
+
+                A pull request that merges into `$baseRef` must increment the version in
+                `${VersionGradleFile.NAME}`. Publishing runs on every push to the base branch,
+                so a non-incremented version would collide with the already-published artifact.
+
+                Bump the version (e.g. run `/bump-version`) and push again.
+
+                To disable this check, run Gradle with `-x $name`.
+                """.trimIndent()
+            )
+        }
+    }
+
+    /**
+     * Tells whether the build runs inside the dedicated `Version Guard` workflow.
+     *
+     * That workflow fetches the base branch before invoking this task and signals it by
+     * setting the `VERSION_GUARD` environment variable to `true`. The variable is the
+     * authoritative marker that `origin/<base>` is present, so the base-branch comparison
+     * may run; see [IncrementGuard.shouldCompareToBase].
+     */
+    private fun underVersionGuard(): Boolean =
+        "true".equals(System.getenv("VERSION_GUARD"))
+
+    /**
+     * Resolves the base-branch publishing version to compare [version] against, or `null`
+     * when the comparison does not apply.
+     *
+     * Returns `null` (skipping the check) when the publishing-version property cannot be
+     * identified in the working-tree `version.gradle.kts`, or when the base branch has no
+     * comparable value (the file is absent or newly introduced). Throws via
+     * [VersionGradleFile.contentInBase] when the base ref itself cannot be resolved.
+     */
+    private fun baseVersionToCompare(baseRef: String): String? {
+        val headContent = VersionGradleFile.contentUnder(project.rootDir)
+        val key = headContent?.let { VersionGradleFile.keyForValue(it, version) }
+        if (key == null) {
+            logger.warn(
+                "Could not identify the publishing-version property matching `$version` in " +
+                    "`${VersionGradleFile.NAME}`; skipping the base-branch increment check."
+            )
+            return null
+        }
+        val baseContent = VersionGradleFile.contentInBase(project.rootDir, baseRef)
+        val baseVersion = baseContent?.let { VersionGradleFile.valueForKey(it, key) }
+        if (baseVersion == null) {
+            logger.info(
+                "No comparable `$key` in `${VersionGradleFile.NAME}` on base `$baseRef` " +
+                    "(absent or newly introduced); skipping the base-branch increment check."
+            )
+        }
+        return baseVersion
+    }
+
+    /**
+     * Verifies that the current [version] has not been published to the target Maven
+     * repository yet.
+     *
+     * Both the `releases` and `snapshots` repositories are checked; artifacts in either
+     * may not be overwritten.
+     */
+    private fun checkNotPublished() {
         val artifact = "${project.artifactPath()}/${MavenMetadata.FILE_NAME}"
         val snapshots = repository.target(snapshots = true)
         checkInRepo(snapshots, artifact)
@@ -76,7 +190,7 @@ open class CheckVersionIncrement : DefaultTask() {
                     """
                     The version `$version` is already published to the Maven repository `$repoUrl`.
                     Try incrementing the library version.
-                    All available versions are: ${versions?.joinToString(separator = ", ")}.
+                    All available versions are: ${versions.joinToString(separator = ", ")}.
 
                     To disable this check, run Gradle with `-x $name`.
                     """.trimIndent()
@@ -114,34 +228,3 @@ open class CheckVersionIncrement : DefaultTask() {
         return result
     }
 }
-
-private data class MavenMetadata(var versioning: Versioning = Versioning()) {
-
-    companion object {
-
-        const val FILE_NAME = "maven-metadata.xml"
-
-        private val mapper = XmlMapper()
-
-        init {
-            mapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-        }
-
-        /**
-         * Fetches the metadata for the repository and parses the document.
-         *
-         * <p>If the document could not be found, assumes that the module was never
-         * released and thus has no metadata.
-         */
-        fun fetchAndParse(url: URL): MavenMetadata? {
-            return try {
-                val metadata = mapper.readValue(url, MavenMetadata::class.java)
-                metadata
-            } catch (_: FileNotFoundException) {
-                null
-            }
-        }
-    }
-}
-
-private data class Versioning(var versions: List<String> = listOf())

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/IncrementGuard.kt
@@ -30,7 +30,6 @@ package io.spine.gradle.publish
 
 import io.spine.gradle.Build
 import io.spine.gradle.SpineTaskGroup
-import io.spine.gradle.base.check
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -40,9 +39,10 @@ import org.gradle.api.publish.maven.tasks.PublishToMavenLocal
  * Gradle plugin that adds a [CheckVersionIncrement] task verifying that the
  * project version was incremented before its artifacts are published.
  *
- * The task — named `checkVersionIncrement` — runs before the `check` task and
- * before any `publishToMavenLocal` task. It actually executes only when the
- * verification is meaningful; see [apply].
+ * The task — named `checkVersionIncrement` — is run directly by the `Version Guard`
+ * CI workflow and before any `publishToMavenLocal` task. It is deliberately kept out
+ * of the `check` lifecycle, and actually executes only when the verification is
+ * meaningful; see [apply].
  */
 class IncrementGuard : Plugin<Project> {
 
@@ -86,6 +86,25 @@ class IncrementGuard : Plugin<Project> {
         ): Boolean = ciPullRequest || (!onCi && localPublish)
 
         /**
+         * Tells whether [CheckVersionIncrement] should compare the project version against
+         * the base branch.
+         *
+         * The comparison reads `origin/<base>:version.gradle.kts`, so it needs the base
+         * branch to have been fetched. Only the dedicated `Version Guard` workflow fetches it
+         * and sets the `VERSION_GUARD` environment variable, which [CheckVersionIncrement]
+         * passes here as the [underVersionGuard] flag; the workflow runs for pull requests, so
+         * a non-blank [baseRef] is required as well.
+         *
+         * Every other CI build (e.g. the Ubuntu and Windows builds) pulls the check into the
+         * task graph through `publishToMavenLocal` but runs a shallow checkout without the
+         * base ref. Such builds report `underVersionGuard = false`, so the comparison is
+         * skipped and `checkNotPublished` stays the guard — otherwise the comparison would
+         * fail closed on `origin/<base>` and break every pull request.
+         */
+        internal fun shouldCompareToBase(underVersionGuard: Boolean, baseRef: String?): Boolean =
+            underVersionGuard && !baseRef.isNullOrBlank()
+
+        /**
          * Tells whether [tasks] contains a Maven Local publishing task that
          * belongs to the given [project].
          *
@@ -98,14 +117,21 @@ class IncrementGuard : Plugin<Project> {
     }
 
     /**
-     * Adds the [CheckVersionIncrement] task to the [target] project and wires it
-     * into two execution paths:
+     * Adds the [CheckVersionIncrement] task to the [target] project and makes every
+     * `publishToMavenLocal` task depend on it, so that a local publish — used by
+     * integration tests that consume artifacts from `~/.m2` — cannot overwrite an
+     * already published version.
      *
-     *  1. The `check` task depends on it, so that CI pull requests verify
-     *     the increment.
-     *  2. Every `publishToMavenLocal` task depends on it, so that a local publish —
-     *     used by integration tests that consume artifacts from `~/.m2` — cannot
-     *     overwrite an already published version.
+     * The CI pull-request increment check is driven separately by the `Version Guard`
+     * workflow (`increment-guard.yml`), which invokes `checkVersionIncrement` by name after
+     * fetching the base branch and setting `VERSION_GUARD` — the signal that gates
+     * [CheckVersionIncrement]'s strict base-branch comparison (see [shouldCompareToBase]).
+     * The task is intentionally not wired into the `check` lifecycle: the version check
+     * belongs to the publishing path, not to generic `check` runs. A build that still pulls
+     * the task in through `publishToMavenLocal` (e.g. the Ubuntu/Windows CI builds, which
+     * publish locally to feed integration tests) stays green, because the base comparison —
+     * which reads `origin/<base>` and would otherwise fail closed on a shallow checkout — is
+     * skipped outside the `Version Guard` workflow.
      *
      * The task is always created and wired, but its action runs only when:
      *  1. the build is a GitHub Actions pull request targeting a default
@@ -134,12 +160,15 @@ class IncrementGuard : Plugin<Project> {
             }
         }
 
-        // Verify the increment on CI pull requests via the `check` lifecycle task.
-        tasks.check.configure { dependsOn(checkVersion) }
+        // The CI pull-request increment check is run by the `Version Guard` workflow,
+        // which calls `checkVersionIncrement` directly after fetching the base branch.
+        // It is intentionally not a dependency of `check`: that would run it in every
+        // `./gradlew build` (e.g. the Ubuntu/Windows CI builds), where `origin/<base>`
+        // is not fetched and the fail-closed base comparison would break the build.
 
-        // Verify it before publishing to Maven Local too: integration tests in this
-        // and sibling projects consume the freshly published artifacts from `~/.m2`,
-        // so a non-incremented version would let them pick up a stale artifact.
+        // Verify before publishing to Maven Local: integration tests in this and
+        // sibling projects consume the freshly published artifacts from `~/.m2`, so a
+        // non-incremented version would let them pick up a stale artifact.
         tasks.withType(PublishToMavenLocal::class.java).configureEach {
             dependsOn(checkVersion)
         }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/MavenMetadata.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/MavenMetadata.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle.publish
+
+import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import java.io.FileNotFoundException
+import java.net.URL
+
+/**
+ * A minimal model of a Maven `maven-metadata.xml` document, exposing the published
+ * versions of an artifact.
+ *
+ * Instances are produced by [XmlMapper] from a registry response; only the `<versioning>`
+ * element is mapped, and unknown elements are ignored.
+ *
+ * @property versioning The `<versioning>` element holding the list of published versions.
+ *   It is `var` with a default value purely to support deserialization: `buildSrc` uses a
+ *   plain [XmlMapper] without the Kotlin module, so Jackson instantiates this class through
+ *   the synthesized no-arg constructor and then assigns the property through its setter. The
+ *   mutability is required by Jackson, not used by our own code; a `val` would silently
+ *   leave the version list empty.
+ */
+internal data class MavenMetadata(var versioning: Versioning = Versioning()) {
+
+    companion object {
+
+        const val FILE_NAME = "maven-metadata.xml"
+
+        private val mapper = XmlMapper()
+
+        init {
+            mapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+        }
+
+        /**
+         * Fetches the metadata for the repository and parses the document.
+         *
+         * If the document could not be found, assumes that the module was never
+         * released and thus has no metadata.
+         */
+        fun fetchAndParse(url: URL): MavenMetadata? {
+            return try {
+                val metadata = mapper.readValue(url, MavenMetadata::class.java)
+                metadata
+            } catch (_: FileNotFoundException) {
+                null
+            }
+        }
+    }
+}
+
+/**
+ * The `<versioning>` element of a `maven-metadata.xml` document, listing the published versions.
+ *
+ * @property versions The published version strings. It is `var` for the same reason as
+ *   [MavenMetadata.versioning]: Jackson assigns it through the setter during deserialization
+ *   (`buildSrc` has no Kotlin module), so a `val` would leave it empty.
+ */
+internal data class Versioning(var versions: List<String> = listOf())

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/DependencyWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/DependencyWriter.kt
@@ -27,6 +27,7 @@
 package io.spine.gradle.report.pom
 
 import groovy.xml.MarkupBuilder
+import io.spine.gradle.VersionComparator
 import java.io.Writer
 import java.util.*
 import kotlin.reflect.full.isSubclassOf

--- a/buildSrc/src/test/kotlin/io/spine/gradle/VersionComparatorSpec.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/VersionComparatorSpec.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle
+
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`VersionComparator` should")
+internal class VersionComparatorSpec {
+
+    /**
+     * Asserts that [newer] compares above [older], checking both directions.
+     */
+    private fun assertNewer(newer: String, older: String) {
+        VersionComparator.compare(newer, older) shouldBeGreaterThan 0
+        VersionComparator.compare(older, newer) shouldBeLessThan 0
+    }
+
+    @Test
+    fun `compare numeric segments as numbers`() {
+        assertNewer("10.0.0", "9.2.0")
+        assertNewer("2.10.0", "2.9.1")
+        assertNewer("1.0.10", "1.0.9")
+    }
+
+    @Test
+    fun `compare numeric qualifier segments as numbers`() {
+        assertNewer("2.0.0-SNAPSHOT.100", "2.0.0-SNAPSHOT.99")
+        assertNewer("2.0.0-SNAPSHOT.100", "2.0.0-SNAPSHOT.070")
+    }
+
+    @Test
+    fun `treat a release as newer than its pre-release`() {
+        assertNewer("2.0.0", "2.0.0-SNAPSHOT.100")
+        assertNewer("1.0.0", "1.0.0-RC.2")
+    }
+
+    @Test
+    fun `treat a longer version as newer when the common segments are equal`() {
+        assertNewer("1.0.1", "1.0")
+        assertNewer("1.0.0-RC.1", "1.0.0-RC")
+    }
+
+    @Test
+    fun `ignore the case of textual segments`() {
+        assertNewer("1.0.0-snapshot.10", "1.0.0-SNAPSHOT.2")
+        VersionComparator.compare("1.0.0-RC", "1.0.0-rc") shouldBe 0
+    }
+
+    @Test
+    fun `order a numeric segment before a textual one`() {
+        assertNewer("1.0.0-alpha", "1.0.0-1")
+    }
+
+    @Test
+    fun `treat equal versions as equal`() {
+        VersionComparator.compare("2.0.0-SNAPSHOT.070", "2.0.0-SNAPSHOT.070") shouldBe 0
+        VersionComparator.compare("31.1-jre", "31.1-jre") shouldBe 0
+    }
+}

--- a/buildSrc/src/test/kotlin/io/spine/gradle/VersionGradleFileSpec.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/VersionGradleFileSpec.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`VersionGradleFile` should read the publishing version")
+internal class VersionGradleFileSpec {
+
+    @Test
+    fun `declared as a literal`() {
+        val content = """
+            val versionToPublish: String by extra("2.0.0-SNAPSHOT.182")
+        """.trimIndent()
+
+        VersionGradleFile.keyForValue(content, "2.0.0-SNAPSHOT.182") shouldBe "versionToPublish"
+        VersionGradleFile.valueForKey(content, "versionToPublish") shouldBe "2.0.0-SNAPSHOT.182"
+    }
+
+    @Test
+    fun `declared as an alias to another 'extra'`() {
+        val content = """
+            val compilerVersion: String by extra("2.0.0-SNAPSHOT.043")
+            val versionToPublish by extra(compilerVersion)
+        """.trimIndent()
+
+        VersionGradleFile.valueForKey(content, "versionToPublish") shouldBe "2.0.0-SNAPSHOT.043"
+        VersionGradleFile.valueForKey(content, "compilerVersion") shouldBe "2.0.0-SNAPSHOT.043"
+    }
+
+    @Test
+    fun `declared as an alias to a plain 'val'`() {
+        val content = """
+            val base = "2.0.0-SNAPSHOT.043"
+            val versionToPublish by extra(base)
+        """.trimIndent()
+
+        VersionGradleFile.valueForKey(content, "versionToPublish") shouldBe "2.0.0-SNAPSHOT.043"
+    }
+
+    @Test
+    fun `identified by the resolved project version, not a hard-coded name`() {
+        val content = """
+            val kotlinVersion: String by extra("2.1.0")
+            val versionToPublish: String by extra("2.0.0-SNAPSHOT.182")
+        """.trimIndent()
+
+        VersionGradleFile.keyForValue(content, "2.0.0-SNAPSHOT.182") shouldBe "versionToPublish"
+    }
+
+    @Test
+    fun `absent when no property matches`() {
+        val content = """
+            val versionToPublish: String by extra("2.0.0-SNAPSHOT.182")
+        """.trimIndent()
+
+        VersionGradleFile.keyForValue(content, "9.9.9") shouldBe null
+        VersionGradleFile.valueForKey(content, "missing") shouldBe null
+    }
+}

--- a/buildSrc/src/test/kotlin/io/spine/gradle/publish/IncrementGuardTest.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/publish/IncrementGuardTest.kt
@@ -27,10 +27,12 @@
 package io.spine.gradle.publish
 
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.spine.gradle.publish.IncrementGuard.Companion.localPublishPlanned
 import io.spine.gradle.publish.IncrementGuard.Companion.mustVerify
 import io.spine.gradle.publish.IncrementGuard.Companion.shouldCheckVersion
+import io.spine.gradle.publish.IncrementGuard.Companion.shouldCompareToBase
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.publish.maven.tasks.PublishToMavenLocal
@@ -115,6 +117,33 @@ class IncrementGuardTest {
     }
 
     @Nested
+    inner class `compare against the base branch` {
+
+        @Test
+        fun `inside the Version Guard workflow with a base branch`() {
+            shouldCompareToBase(underVersionGuard = true, baseRef = "master") shouldBe true
+            shouldCompareToBase(underVersionGuard = true, baseRef = "2.x-jdk8-master") shouldBe true
+        }
+    }
+
+    @Nested
+    inner class `not compare against the base branch` {
+
+        @Test
+        fun `outside the Version Guard workflow`() {
+            // The Ubuntu/Windows CI builds pull the task in via `publishToMavenLocal`,
+            // but they never fetch the base ref, so `VERSION_GUARD` is unset.
+            shouldCompareToBase(underVersionGuard = false, baseRef = "master") shouldBe false
+        }
+
+        @Test
+        fun `when no base branch is present`() {
+            shouldCompareToBase(underVersionGuard = true, baseRef = null) shouldBe false
+            shouldCompareToBase(underVersionGuard = true, baseRef = "") shouldBe false
+        }
+    }
+
+    @Nested
     inner class `detect a Maven Local publish` {
 
         @Test
@@ -145,14 +174,6 @@ class IncrementGuardTest {
     inner class `make 'checkVersionIncrement' a dependency of` {
 
         @Test
-        fun `the 'check' task`() {
-            val project = guardedProject()
-            val check = project.tasks.getByName("check")
-
-            check.dependencyNames() shouldContain IncrementGuard.taskName
-        }
-
-        @Test
         fun `every Maven Local publishing task`() {
             val project = guardedProject()
             val localPublish = project.tasks.register(
@@ -161,6 +182,22 @@ class IncrementGuardTest {
             ).get()
 
             localPublish.dependencyNames() shouldContain IncrementGuard.taskName
+        }
+    }
+
+    @Nested
+    inner class `keep 'checkVersionIncrement' out of` {
+
+        @Test
+        fun `the 'check' lifecycle task`() {
+            // The CI check runs via the `Version Guard` workflow, which fetches the
+            // base branch first. Wiring it into `check` would run it in every
+            // `./gradlew build`, where `origin/<base>` is absent and the fail-closed
+            // base comparison would break the build.
+            val project = guardedProject()
+            val check = project.tasks.getByName("check")
+
+            check.dependencyNames() shouldNotContain IncrementGuard.taskName
         }
     }
 }

--- a/buildSrc/src/test/kotlin/io/spine/gradle/publish/MavenMetadataSpec.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/publish/MavenMetadataSpec.kt
@@ -24,14 +24,30 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.test
+package io.spine.gradle.publish
 
-// https://github.com/testcontainers/testcontainers-java
-@Suppress("unused", "ConstPropertyName")
-object Testcontainers {
-    private const val version = "1.21.4"
-    private const val group = "org.testcontainers"
-    const val lib = "$group:testcontainers:$version"
-    const val junitJupiter = "$group:junit-jupiter:$version"
-    const val gcloud = "$group:gcloud:$version"
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import io.kotest.matchers.collections.shouldContainExactly
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`MavenMetadata` should")
+internal class MavenMetadataSpec {
+
+    /**
+     * Round-trips through the same [XmlMapper] used in production, asserting the version list
+     * survives. This guards the `var` properties of [MavenMetadata] and [Versioning]: a `val`
+     * (or `internal`-mangled setter) would leave the list empty after deserialization, silently
+     * disabling the "already published" check.
+     */
+    @Test
+    fun `survive a Jackson round-trip, keeping its versions`() {
+        val versions = listOf("2.0.0-SNAPSHOT.79", "2.0.0-SNAPSHOT.80", "2.0.0-SNAPSHOT.81")
+        val mapper = XmlMapper()
+
+        val xml = mapper.writeValueAsString(MavenMetadata(Versioning(versions)))
+        val parsed = mapper.readValue(xml, MavenMetadata::class.java)
+
+        parsed.versioning.versions shouldContainExactly versions
+    }
 }

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -60,7 +60,7 @@
 1.  **Group** : com.querydsl. **Name** : querydsl-sql. **Version** : 5.1.0.
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.zaxxer. **Name** : HikariCP. **Version** : 5.0.1.
+1.  **Group** : com.zaxxer. **Name** : HikariCP. **Version** : 7.1.0.
      * **Project URL:** [https://github.com/brettwooldridge/HikariCP](https://github.com/brettwooldridge/HikariCP)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -429,7 +429,7 @@
      * **Project URL:** [https://github.com/square/kotlinpoet](https://github.com/square/kotlinpoet)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.zaxxer. **Name** : HikariCP. **Version** : 5.0.1.
+1.  **Group** : com.zaxxer. **Name** : HikariCP. **Version** : 7.1.0.
      * **Project URL:** [https://github.com/brettwooldridge/HikariCP](https://github.com/brettwooldridge/HikariCP)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1071,7 +1071,7 @@
      * **Project URL:** [https://github.com/hrldcpr/pcollections](https://github.com/hrldcpr/pcollections)
      * **License:** [The MIT License](https://opensource.org/licenses/mit-license.php)
 
-1.  **Group** : org.postgresql. **Name** : postgresql. **Version** : 42.7.4.
+1.  **Group** : org.postgresql. **Name** : postgresql. **Version** : 42.7.11.
      * **Project URL:** [https://jdbc.postgresql.org](https://jdbc.postgresql.org)
      * **License:** [BSD-2-Clause](https://jdbc.postgresql.org/about/license.html)
 

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1071,6 +1071,10 @@
      * **Project URL:** [https://github.com/hrldcpr/pcollections](https://github.com/hrldcpr/pcollections)
      * **License:** [The MIT License](https://opensource.org/licenses/mit-license.php)
 
+1.  **Group** : org.postgresql. **Name** : postgresql. **Version** : 42.7.4.
+     * **Project URL:** [https://jdbc.postgresql.org](https://jdbc.postgresql.org)
+     * **License:** [BSD-2-Clause](https://jdbc.postgresql.org/about/license.html)
+
 1.  **Group** : org.reflections. **Name** : reflections. **Version** : 0.10.2.
      * **Project URL:** [http://github.com/ronmamo/reflections](http://github.com/ronmamo/reflections)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1112,6 +1116,10 @@
      * **Project URL:** [https://java.testcontainers.org](https://java.testcontainers.org)
      * **License:** [MIT](http://opensource.org/licenses/MIT)
 
+1.  **Group** : org.testcontainers. **Name** : postgresql. **Version** : 1.21.4.
+     * **Project URL:** [https://java.testcontainers.org](https://java.testcontainers.org)
+     * **License:** [MIT](http://opensource.org/licenses/MIT)
+
 1.  **Group** : org.testcontainers. **Name** : testcontainers. **Version** : 1.21.4.
      * **Project URL:** [https://java.testcontainers.org](https://java.testcontainers.org)
      * **License:** [MIT](http://opensource.org/licenses/MIT)
@@ -1131,6 +1139,6 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 26 18:56:11 WEST 2026** using 
+This report was generated on **Fri Jun 26 20:14:50 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-rdbms:2.0.0-SNAPSHOT.103`
+# Dependencies of `io.spine:spine-rdbms:2.0.0-SNAPSHOT.104`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1131,6 +1131,6 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 26 17:52:00 WEST 2026** using 
+This report was generated on **Fri Jun 26 18:56:11 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-rdbms:2.0.0-SNAPSHOT.102`
+# Dependencies of `io.spine:spine-rdbms:2.0.0-SNAPSHOT.103`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1131,6 +1131,6 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jun 24 18:56:02 WEST 2026** using 
+This report was generated on **Fri Jun 26 17:52:00 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>jdbc-storage</artifactId>
-<version>2.0.0-SNAPSHOT.102</version>
+<version>2.0.0-SNAPSHOT.103</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -156,6 +156,12 @@ all modules and does not describe the project structure per-subproject.
     <scope>test</scope>
   </dependency>
   <dependency>
+    <groupId>org.postgresql</groupId>
+    <artifactId>postgresql</artifactId>
+    <version>42.7.4</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-simple</artifactId>
     <version>2.0.18</version>
@@ -170,6 +176,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.testcontainers</groupId>
     <artifactId>mysql</artifactId>
+    <version>1.21.4</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.testcontainers</groupId>
+    <artifactId>postgresql</artifactId>
     <version>1.21.4</version>
     <scope>test</scope>
   </dependency>

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -32,7 +32,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.zaxxer</groupId>
     <artifactId>HikariCP</artifactId>
-    <version>5.0.1</version>
+    <version>7.1.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -158,7 +158,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.postgresql</groupId>
     <artifactId>postgresql</artifactId>
-    <version>42.7.4</version>
+    <version>42.7.11</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>jdbc-storage</artifactId>
-<version>2.0.0-SNAPSHOT.103</version>
+<version>2.0.0-SNAPSHOT.104</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/docs/tables.md
+++ b/docs/tables.md
@@ -23,6 +23,8 @@ E.g. a table name for an Entity, which has a state declared by `bar.acme.Project
 Each table created has the following structure:
 
 * `ID` — the identifier of the record (Entity, or a standalone message). Primary key.
+  On MySQL, string identifiers use a binary collation so that they are matched case-sensitively;
+  see [Case sensitivity on MySQL](type-mapping.md#case-sensitivity-on-mysql).
 * `bytes` — stores the serialized Proto message (Entity state, or a standalone message value).
 * Columns defined either
      * via `Entity`'s `(column)` option;

--- a/docs/type-mapping.md
+++ b/docs/type-mapping.md
@@ -6,8 +6,9 @@ The mapping defines correspondence of `Type` to a name for a particular database
 
 The type mapping is selected automatically based on the database product name and version,
 as reported by the JDBC driver's `DatabaseMetaData`.
-If there is no predefined mapping for the database,
-mapping for MySQL 9.7 will be used as the default.
+If there is no exact match, a MySQL server of another version still uses the MySQL 9.7 mapping
+(its binary collation applies across MySQL versions), while any other unrecognized database falls
+back to a neutral mapping with portable type names and no dialect-specific clauses.
 
 ## Default values
 

--- a/docs/type-mapping.md
+++ b/docs/type-mapping.md
@@ -49,6 +49,29 @@ the `VARCHAR(512)` primary key stays within InnoDB's index-length limit.
 PostgreSQL and H2 compare string data case-sensitively by default and therefore need no such
 collation.
 
+### Migrating existing tables
+
+The framework never changes the structure of a table that already exists, so a table created
+before this change keeps its original, case-insensitive collation — only newly created tables
+get the binary collation automatically. Re-collate the character columns of each existing table
+by hand. The simplest way is to convert the whole table:
+
+```sql
+ALTER TABLE `<table>` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+```
+
+This re-collates every `VARCHAR`/`TEXT` column — the `ID` and all string columns — to the binary
+collation. For a table already stored as `utf8mb4` the character set is unchanged, so only the
+collation metadata and the affected indexes are rebuilt. To re-collate a single column instead:
+
+```sql
+ALTER TABLE `<table>` MODIFY `ID` VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;
+```
+
+> ⚠️ Re-collating prevents *future* collisions but cannot undo past ones. If `"name"` and
+> `"Name"` were both written while the column was case-insensitive, the table already holds a
+> single merged row and the overwritten record is gone — audit such tables before migrating.
+
 ## Custom mapping
 
 If the automatically selected mapping doesn't match your requirements, a custom mapping can be

--- a/docs/type-mapping.md
+++ b/docs/type-mapping.md
@@ -6,9 +6,10 @@ The mapping defines correspondence of `Type` to a name for a particular database
 
 The type mapping is selected automatically based on the database product name and version,
 as reported by the JDBC driver's `DatabaseMetaData`.
-If there is no exact match, a MySQL server of another version still uses the MySQL 9.7 mapping
-(its binary collation applies across MySQL versions), while any other unrecognized database falls
-back to a neutral mapping with portable type names and no dialect-specific clauses.
+If there is no exact match, a recognized database (MySQL, PostgreSQL, or H2) reported at another
+version still uses that product's mapping — its dialect-specific type names apply across versions.
+Only an unrecognized database falls back to a neutral mapping with portable type names and no
+dialect-specific clauses.
 
 ## Default values
 

--- a/docs/type-mapping.md
+++ b/docs/type-mapping.md
@@ -11,24 +11,50 @@ mapping for MySQL 9.7 will be used as the default.
 
 ## Default values
 
-|    Type    |  MySQL 9.7   | PostgreSQL 10.1  |
-|:----------:|:------------:|:----------------:|
-| BYTE_ARRAY |     BLOB     |      BYTEA       |
-|    INT     |     INT      |       INT        |
-|    LONG    |    BIGINT    |      BIGINT      |
-|   FLOAT    |    FLOAT     |       REAL       |
-|   DOUBLE   |    DOUBLE    | DOUBLE PRECISION |
-| STRING_255 | VARCHAR(255) |   VARCHAR(255)   |
-| STRING_512 | VARCHAR(512) |   VARCHAR(512)   |
-|   STRING   |     TEXT     |       TEXT       |
-|  BOOLEAN   |   BOOLEAN    |     BOOLEAN      |
+|    Type    |          MySQL 9.7          | PostgreSQL 10.1  |
+|:----------:|:---------------------------:|:----------------:|
+| BYTE_ARRAY |            BLOB             |      BYTEA       |
+|    INT     |             INT             |       INT        |
+|    LONG    |           BIGINT            |      BIGINT      |
+|   FLOAT    |            FLOAT            |       REAL       |
+|   DOUBLE   |           DOUBLE            | DOUBLE PRECISION |
+| STRING_255 | VARCHAR(255) <sup>(1)</sup> |   VARCHAR(255)   |
+| STRING_512 | VARCHAR(512) <sup>(1)</sup> |   VARCHAR(512)   |
+|   STRING   |     TEXT <sup>(1)</sup>     |       TEXT       |
+|  BOOLEAN   |           BOOLEAN           |     BOOLEAN      |
+
+<sup>(1)</sup> On MySQL the character-based types additionally carry a
+`CHARACTER SET utf8mb4 COLLATE utf8mb4_bin` clause. See
+[Case sensitivity on MySQL](#case-sensitivity-on-mysql) below.
+
+## Case sensitivity on MySQL
+
+MySQL compares non-binary string types (`VARCHAR`, `TEXT`)
+[case- and accent-insensitively](https://dev.mysql.com/doc/refman/8.4/en/case-sensitivity.html)
+by default. Entity identifiers and `String` columns are stored in such types, so two values that
+differ only by case — for example, a username `"name"` and a distinct username `"Name"` — would
+be treated as equal. Commands addressed to one entity would then be routed to the other, and the
+two records would collide on a single row.
+
+To prevent this, the predefined MySQL mapping appends an explicit binary collation
+(`CHARACTER SET utf8mb4 COLLATE utf8mb4_bin`) to every character-based column type, restoring
+exact, case-sensitive matching. The collation does not change how many bytes a value occupies, so
+the `VARCHAR(512)` primary key stays within InnoDB's index-length limit.
+
+> ⚠️ **Do not drop the binary collation from MySQL string columns.** Reverting them to a plain
+> `VARCHAR`/`TEXT` (or to a `_ci` collation) reintroduces the collision described above. When
+> supplying a [custom mapping](#custom-mapping) for MySQL, keep the collation on the
+> `STRING_255`, `STRING_512`, and `STRING` types.
+
+PostgreSQL and H2 compare string data case-sensitively by default and therefore need no such
+collation.
 
 ## Custom mapping
 
 If the automatically selected mapping doesn't match your requirements, a custom mapping can be
 specified during creation of `JdbcStorageFactory`.
 The library exposes `TypeMappingBuilder.mappingBuilder()` shortcut, returning a builder
-already containing the mappings for all data types, as per MySQL 9.7 mapping scheme.
+already containing default names for all data types.
 The designed usage scenario is to override the values for required keys:
 
 ```java
@@ -42,3 +68,9 @@ var factory = JdbcStorageFactory.newBuilder()
                   //...
                   .build()
 ```
+
+The names returned by `mappingBuilder()` are the plain defaults shared by all databases; the
+predefined `MYSQL_9_7` mapping layers the
+[binary collation](#case-sensitivity-on-mysql) on top of them. When you build a custom mapping
+for MySQL, add the collation to the `STRING_255`, `STRING_512`, and `STRING` types yourself, e.g.
+`.add(Type.STRING_512, "VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin")`.

--- a/rdbms/build.gradle.kts
+++ b/rdbms/build.gradle.kts
@@ -25,16 +25,15 @@
  */
 
 import io.spine.dependency.lib.Grpc
-import io.spine.dependency.lib.Hikari
-import io.spine.dependency.lib.QueryDsl
 import io.spine.dependency.lib.Slf4J
 import io.spine.dependency.local.CoreJvm
 import io.spine.dependency.storage.H2
+import io.spine.dependency.storage.Hikari
 import io.spine.dependency.storage.HsqlDb
 import io.spine.dependency.storage.MySql
 import io.spine.dependency.storage.PostgreSql
+import io.spine.dependency.storage.QueryDsl
 import io.spine.dependency.test.Testcontainers
-import org.gradle.api.tasks.testing.Test
 
 plugins {
     module

--- a/rdbms/build.gradle.kts
+++ b/rdbms/build.gradle.kts
@@ -32,6 +32,7 @@ import io.spine.dependency.local.CoreJvm
 import io.spine.dependency.storage.H2
 import io.spine.dependency.storage.HsqlDb
 import io.spine.dependency.storage.MySql
+import io.spine.dependency.storage.PostgreSql
 import io.spine.dependency.test.Testcontainers
 import org.gradle.api.tasks.testing.Test
 
@@ -78,6 +79,10 @@ dependencies {
         exclude(group = "org.jetbrains")
     }
     testImplementation(MySql.connector)
+    testImplementation(Testcontainers.postgresql) {
+        exclude(group = "org.jetbrains")
+    }
+    testImplementation(PostgreSql.connector)
 
     testRuntimeOnly(Slf4J.simple)
 }

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/MySqlTypeNames.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/MySqlTypeNames.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.jdbc;
+
+/**
+ * SQL type names specific to MySQL, which differ from the
+ * {@linkplain TypeMappingBuilder default mapping}.
+ */
+final class MySqlTypeNames {
+
+    /**
+     * The character set and binary collation appended to every character-based column type.
+     *
+     * <p>By default, MySQL uses a case- and accent-insensitive collation for non-binary
+     * string types, so {@code 'name'} and {@code 'Name'} compare as equal. Entity
+     * identifiers and {@code String} columns must be matched exactly; otherwise distinct
+     * identifiers collide and commands for one entity get routed to another. A binary
+     * collation restores exact, case-sensitive matching.
+     *
+     * <p>{@code utf8mb4} (rather than the deprecated {@code utf8}/{@code utf8mb3}) is used to
+     * keep the full Unicode range available. The collation does not change the stored byte
+     * width, so the {@code VARCHAR(512)} primary key stays within InnoDB index limits.
+     */
+    private static final String BINARY = "CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
+
+    /** {@code VARCHAR(255)} with a {@linkplain #BINARY binary collation}. */
+    static final String VARCHAR_255 = "VARCHAR(255) " + BINARY;
+
+    /** {@code VARCHAR(512)} with a {@linkplain #BINARY binary collation}. */
+    static final String VARCHAR_512 = "VARCHAR(512) " + BINARY;
+
+    /** {@code TEXT} with a {@linkplain #BINARY binary collation}. */
+    static final String TEXT = "TEXT " + BINARY;
+
+    private MySqlTypeNames() {
+    }
+}

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/PostgreSqlTypeNames.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/PostgreSqlTypeNames.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.jdbc;
+
+/**
+ * SQL type names specific to PostgreSQL, which differ from the
+ * {@linkplain TypeMappingBuilder default mapping}.
+ */
+final class PostgreSqlTypeNames {
+
+    /** The single-precision (4-byte) floating-point type. */
+    static final String REAL = "REAL";
+
+    /**
+     * The double-precision (8-byte) floating-point type.
+     *
+     * <p>Used because PostgreSQL does not recognize a bare {@code DOUBLE}.
+     */
+    static final String DOUBLE_PRECISION = "DOUBLE PRECISION";
+
+    private PostgreSqlTypeNames() {
+    }
+}

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/PredefinedMapping.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/PredefinedMapping.java
@@ -63,6 +63,16 @@ public enum PredefinedMapping implements TypeMapping {
     // Must match `io.spine.dependency.storage.H2.version`.
     H2_2_4("H2", 2, 4, mappingBuilder());
 
+    /**
+     * A portable mapping used by {@link #select(DataSourceWrapper) select} for a database it does
+     * not recognize.
+     *
+     * <p>It exposes the {@linkplain TypeMappingBuilder#mappingBuilder() default} type names with
+     * no dialect-specific clauses — in particular, without the {@linkplain MySql MySQL binary
+     * collation} — so that table creation does not emit DDL an unidentified engine cannot parse.
+     */
+    private static final TypeMapping GENERIC_MAPPING = mappingBuilder().build();
+
     private final TypeMapping typeMapping;
     private final String databaseProductName;
     private final int majorVersion;
@@ -89,8 +99,9 @@ public enum PredefinedMapping implements TypeMapping {
      *
      * @param dataSource
      *         the data source to test suitability
-     * @return the type mapping for the used database or {@linkplain PredefinedMapping#MYSQL_9_7
-     *         mapping for MySQL 9.7} if there is no standard mapping for the database
+     * @return the type mapping for the used database; for an unlisted version of MySQL the
+     *         {@linkplain #MYSQL_9_7 MySQL mapping} is used, and for any other unrecognized
+     *         database the {@linkplain #GENERIC_MAPPING generic mapping} with portable type names
      */
     public static TypeMapping select(DataSourceWrapper dataSource) {
         checkNotNull(dataSource);
@@ -105,7 +116,14 @@ public enum PredefinedMapping implements TypeMapping {
                 return mapping;
             }
         }
-        return MYSQL_9_7;
+        // No exact product-and-version match. A MySQL server of another version still uses the
+        // MySQL mapping, since its binary collation (see `MySql`) is valid across MySQL versions.
+        // Any other, unrecognized database falls back to a generic mapping, whose portable type
+        // names carry no dialect-specific clauses; emitting the MySQL collation to an engine that
+        // cannot parse it would break table creation.
+        var isMysql = metaData.productName()
+                              .equals(MYSQL_9_7.databaseProductName);
+        return isMysql ? MYSQL_9_7 : GENERIC_MAPPING;
     }
 
     @VisibleForTesting

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/PredefinedMapping.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/PredefinedMapping.java
@@ -34,6 +34,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.server.storage.jdbc.Type.BYTE_ARRAY;
 import static io.spine.server.storage.jdbc.Type.DOUBLE;
 import static io.spine.server.storage.jdbc.Type.FLOAT;
+import static io.spine.server.storage.jdbc.Type.STRING;
+import static io.spine.server.storage.jdbc.Type.STRING_255;
+import static io.spine.server.storage.jdbc.Type.STRING_512;
 import static io.spine.server.storage.jdbc.TypeMappingBuilder.mappingBuilder;
 
 /**
@@ -43,7 +46,13 @@ import static io.spine.server.storage.jdbc.TypeMappingBuilder.mappingBuilder;
 public enum PredefinedMapping implements TypeMapping {
 
     // Must match `io.spine.dependency.storage.MySql.version`.
-    MYSQL_9_7("MySQL", 9, 7, mappingBuilder()),
+    //
+    // MySQL compares non-binary string types case- and accent-insensitively by default, so
+    // distinct identifiers like `"name"` and `"Name"` would collide. All character-based column
+    // types therefore carry an explicit binary collation; see the `MySql` helper below.
+    MYSQL_9_7("MySQL", 9, 7, mappingBuilder().add(STRING_255, MySql.VARCHAR_255)
+                                             .add(STRING_512, MySql.VARCHAR_512)
+                                             .add(STRING, MySql.TEXT)),
 
     // PostgreSQL has no bare `DOUBLE` type, and its `FLOAT` is double-precision;
     // map to the single-/double-precision types matching Java `float`/`double`.
@@ -112,6 +121,40 @@ public enum PredefinedMapping implements TypeMapping {
     @VisibleForTesting
     int getMinorVersion() {
         return minorVersion;
+    }
+
+    /**
+     * SQL type names specific to MySQL, which differ from the
+     * {@linkplain TypeMappingBuilder default mapping}.
+     */
+    static final class MySql {
+
+        /**
+         * The character set and binary collation appended to every character-based column type.
+         *
+         * <p>By default, MySQL uses a case- and accent-insensitive collation for non-binary
+         * string types, so {@code 'name'} and {@code 'Name'} compare as equal. Entity
+         * identifiers and {@code String} columns must be matched exactly; otherwise distinct
+         * identifiers collide and commands for one entity get routed to another. A binary
+         * collation restores exact, case-sensitive matching.
+         *
+         * <p>{@code utf8mb4} (rather than the deprecated {@code utf8}/{@code utf8mb3}) is used to
+         * keep the full Unicode range available. The collation does not change the stored byte
+         * width, so the {@code VARCHAR(512)} primary key stays within InnoDB index limits.
+         */
+        private static final String BINARY = "CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
+
+        /** {@code VARCHAR(255)} with a {@linkplain #BINARY binary collation}. */
+        static final String VARCHAR_255 = "VARCHAR(255) " + BINARY;
+
+        /** {@code VARCHAR(512)} with a {@linkplain #BINARY binary collation}. */
+        static final String VARCHAR_512 = "VARCHAR(512) " + BINARY;
+
+        /** {@code TEXT} with a {@linkplain #BINARY binary collation}. */
+        static final String TEXT = "TEXT " + BINARY;
+
+        private MySql() {
+        }
     }
 
     /**

--- a/rdbms/src/main/java/io/spine/server/storage/jdbc/PredefinedMapping.java
+++ b/rdbms/src/main/java/io/spine/server/storage/jdbc/PredefinedMapping.java
@@ -49,16 +49,18 @@ public enum PredefinedMapping implements TypeMapping {
     //
     // MySQL compares non-binary string types case- and accent-insensitively by default, so
     // distinct identifiers like `"name"` and `"Name"` would collide. All character-based column
-    // types therefore carry an explicit binary collation; see the `MySql` helper below.
-    MYSQL_9_7("MySQL", 9, 7, mappingBuilder().add(STRING_255, MySql.VARCHAR_255)
-                                             .add(STRING_512, MySql.VARCHAR_512)
-                                             .add(STRING, MySql.TEXT)),
+    // types therefore carry an explicit binary collation; see `MySqlTypeNames`.
+    MYSQL_9_7("MySQL", 9, 7,
+              mappingBuilder().add(STRING_255, MySqlTypeNames.VARCHAR_255)
+                              .add(STRING_512, MySqlTypeNames.VARCHAR_512)
+                              .add(STRING, MySqlTypeNames.TEXT)),
 
     // PostgreSQL has no bare `DOUBLE` type, and its `FLOAT` is double-precision;
     // map to the single-/double-precision types matching Java `float`/`double`.
-    POSTGRESQL_10_1("PostgreSQL", 10, 1, mappingBuilder().add(BYTE_ARRAY, "BYTEA")
-                                                         .add(FLOAT, PostgreSql.REAL)
-                                                         .add(DOUBLE, PostgreSql.DOUBLE_PRECISION)),
+    POSTGRESQL_10_1("PostgreSQL", 10, 1,
+                    mappingBuilder().add(BYTE_ARRAY, "BYTEA")
+                                    .add(FLOAT, PostgreSqlTypeNames.REAL)
+                                    .add(DOUBLE, PostgreSqlTypeNames.DOUBLE_PRECISION)),
 
     // Must match `io.spine.dependency.storage.H2.version`.
     H2_2_4("H2", 2, 4, mappingBuilder());
@@ -68,8 +70,8 @@ public enum PredefinedMapping implements TypeMapping {
      * not recognize.
      *
      * <p>It exposes the {@linkplain TypeMappingBuilder#mappingBuilder() default} type names with
-     * no dialect-specific clauses — in particular, without the {@linkplain MySql MySQL binary
-     * collation} — so that table creation does not emit DDL an unidentified engine cannot parse.
+     * no dialect-specific clauses — in particular, without the {@linkplain MySqlTypeNames MySQL
+     * binary collation} — so that table creation does not emit DDL an unknown engine cannot parse.
      */
     private static final TypeMapping GENERIC_MAPPING = mappingBuilder().build();
 
@@ -99,31 +101,32 @@ public enum PredefinedMapping implements TypeMapping {
      *
      * @param dataSource
      *         the data source to test suitability
-     * @return the type mapping for the used database; for an unlisted version of MySQL the
-     *         {@linkplain #MYSQL_9_7 MySQL mapping} is used, and for any other unrecognized
-     *         database the {@linkplain #GENERIC_MAPPING generic mapping} with portable type names
+     * @return the type mapping for the used database; a recognized product reported at an
+     *         unlisted version still uses that product's mapping, and an unrecognized database
+     *         uses the {@linkplain #GENERIC_MAPPING generic mapping} with portable type names
      */
     public static TypeMapping select(DataSourceWrapper dataSource) {
         checkNotNull(dataSource);
         var metaData = dataSource.metaData();
+        PredefinedMapping sameProduct = null;
         for (var mapping : values()) {
-            var nameMatch = metaData.productName()
-                                    .equals(mapping.databaseProductName);
+            if (!metaData.productName().equals(mapping.databaseProductName)) {
+                continue;
+            }
             var versionMatch =
                     metaData.majorVersion() == mapping.majorVersion
                     && metaData.minorVersion() == mapping.minorVersion;
-            if (nameMatch && versionMatch) {
+            if (versionMatch) {
                 return mapping;
             }
+            sameProduct = mapping;
         }
-        // No exact product-and-version match. A MySQL server of another version still uses the
-        // MySQL mapping, since its binary collation (see `MySql`) is valid across MySQL versions.
-        // Any other, unrecognized database falls back to a generic mapping, whose portable type
-        // names carry no dialect-specific clauses; emitting the MySQL collation to an engine that
-        // cannot parse it would break table creation.
-        var isMysql = metaData.productName()
-                              .equals(MYSQL_9_7.databaseProductName);
-        return isMysql ? MYSQL_9_7 : GENERIC_MAPPING;
+        // A recognized product reported at an unlisted version still uses that product's mapping,
+        // as its dialect-specific type names (the MySQL binary collation, the PostgreSQL
+        // `BYTEA`/`DOUBLE PRECISION`) apply across that product's versions. An unrecognized
+        // database falls back to a generic mapping, whose portable type names carry no
+        // dialect-specific clauses an unknown engine might not parse.
+        return sameProduct != null ? sameProduct : GENERIC_MAPPING;
     }
 
     @VisibleForTesting
@@ -139,59 +142,5 @@ public enum PredefinedMapping implements TypeMapping {
     @VisibleForTesting
     int getMinorVersion() {
         return minorVersion;
-    }
-
-    /**
-     * SQL type names specific to MySQL, which differ from the
-     * {@linkplain TypeMappingBuilder default mapping}.
-     */
-    static final class MySql {
-
-        /**
-         * The character set and binary collation appended to every character-based column type.
-         *
-         * <p>By default, MySQL uses a case- and accent-insensitive collation for non-binary
-         * string types, so {@code 'name'} and {@code 'Name'} compare as equal. Entity
-         * identifiers and {@code String} columns must be matched exactly; otherwise distinct
-         * identifiers collide and commands for one entity get routed to another. A binary
-         * collation restores exact, case-sensitive matching.
-         *
-         * <p>{@code utf8mb4} (rather than the deprecated {@code utf8}/{@code utf8mb3}) is used to
-         * keep the full Unicode range available. The collation does not change the stored byte
-         * width, so the {@code VARCHAR(512)} primary key stays within InnoDB index limits.
-         */
-        private static final String BINARY = "CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
-
-        /** {@code VARCHAR(255)} with a {@linkplain #BINARY binary collation}. */
-        static final String VARCHAR_255 = "VARCHAR(255) " + BINARY;
-
-        /** {@code VARCHAR(512)} with a {@linkplain #BINARY binary collation}. */
-        static final String VARCHAR_512 = "VARCHAR(512) " + BINARY;
-
-        /** {@code TEXT} with a {@linkplain #BINARY binary collation}. */
-        static final String TEXT = "TEXT " + BINARY;
-
-        private MySql() {
-        }
-    }
-
-    /**
-     * SQL type names specific to PostgreSQL, which differ from the
-     * {@linkplain TypeMappingBuilder default mapping}.
-     */
-    static final class PostgreSql {
-
-        /** The single-precision (4-byte) floating-point type. */
-        static final String REAL = "REAL";
-
-        /**
-         * The double-precision (8-byte) floating-point type.
-         *
-         * <p>Used because PostgreSQL does not recognize a bare {@code DOUBLE}.
-         */
-        static final String DOUBLE_PRECISION = "DOUBLE PRECISION";
-
-        private PostgreSql() {
-        }
     }
 }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/PredefinedMappingTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/PredefinedMappingTest.java
@@ -31,11 +31,11 @@ import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichHoldsMetadata;
+import static io.spine.server.storage.jdbc.PostgreSqlTypeNames.DOUBLE_PRECISION;
+import static io.spine.server.storage.jdbc.PostgreSqlTypeNames.REAL;
 import static io.spine.server.storage.jdbc.PredefinedMapping.H2_2_4;
 import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_9_7;
 import static io.spine.server.storage.jdbc.PredefinedMapping.POSTGRESQL_10_1;
-import static io.spine.server.storage.jdbc.PredefinedMapping.PostgreSql.DOUBLE_PRECISION;
-import static io.spine.server.storage.jdbc.PredefinedMapping.PostgreSql.REAL;
 import static io.spine.server.storage.jdbc.PredefinedMapping.select;
 import static io.spine.server.storage.jdbc.Type.DOUBLE;
 import static io.spine.server.storage.jdbc.Type.FLOAT;
@@ -68,14 +68,16 @@ class PredefinedMappingTest {
     }
 
     @Test
-    @DisplayName("not be selected if major versions are different")
-    void notSelectForDifferentVersion() {
+    @DisplayName("select a product's mapping for an unlisted version of that product")
+    void selectByProductNameForUnlistedVersion() {
         var newMajorVersion = mapping.getMajorVersion() + 1;
         var dataSource = whichHoldsMetadata(mapping.getDatabaseProductName(),
                                             newMajorVersion,
                                             mapping.getMinorVersion());
+        // A recognized product at an unlisted version uses that product's dialect mapping,
+        // rather than the generic fallback meant for unknown databases.
         assertThat(select(dataSource))
-                .isNotEqualTo(mapping);
+                .isEqualTo(mapping);
     }
 
     @Test

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/PredefinedMappingTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/PredefinedMappingTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.server.storage.jdbc.GivenDataSource.whichHoldsMetadata;
+import static io.spine.server.storage.jdbc.PredefinedMapping.H2_2_4;
 import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_9_7;
 import static io.spine.server.storage.jdbc.PredefinedMapping.POSTGRESQL_10_1;
 import static io.spine.server.storage.jdbc.PredefinedMapping.PostgreSql.DOUBLE_PRECISION;
@@ -38,6 +39,9 @@ import static io.spine.server.storage.jdbc.PredefinedMapping.PostgreSql.REAL;
 import static io.spine.server.storage.jdbc.PredefinedMapping.select;
 import static io.spine.server.storage.jdbc.Type.DOUBLE;
 import static io.spine.server.storage.jdbc.Type.FLOAT;
+import static io.spine.server.storage.jdbc.Type.STRING;
+import static io.spine.server.storage.jdbc.Type.STRING_255;
+import static io.spine.server.storage.jdbc.Type.STRING_512;
 import static io.spine.testing.TestValues.nullRef;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -86,5 +90,26 @@ class PredefinedMappingTest {
     void mapFloatingPointTypesForPostgres() {
         assertThat(POSTGRESQL_10_1.typeNameFor(FLOAT).value()).isEqualTo(REAL);
         assertThat(POSTGRESQL_10_1.typeNameFor(DOUBLE).value()).isEqualTo(DOUBLE_PRECISION);
+    }
+
+    @Test
+    @DisplayName("map `String` types to case-sensitive binary collations for MySQL")
+    void mapStringTypesForMysqlToBinaryCollation() {
+        assertThat(MYSQL_9_7.typeNameFor(STRING_255).value())
+                .isEqualTo("VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin");
+        assertThat(MYSQL_9_7.typeNameFor(STRING_512).value())
+                .isEqualTo("VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin");
+        assertThat(MYSQL_9_7.typeNameFor(STRING).value())
+                .isEqualTo("TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin");
+    }
+
+    @Test
+    @DisplayName("not apply the MySQL binary collation to other databases")
+    void keepStringTypesPlainForOtherDatabases() {
+        for (var caseSensitiveDb : new PredefinedMapping[]{POSTGRESQL_10_1, H2_2_4}) {
+            assertThat(caseSensitiveDb.typeNameFor(STRING_255).value()).isEqualTo("VARCHAR(255)");
+            assertThat(caseSensitiveDb.typeNameFor(STRING_512).value()).isEqualTo("VARCHAR(512)");
+            assertThat(caseSensitiveDb.typeNameFor(STRING).value()).isEqualTo("TEXT");
+        }
     }
 }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/PredefinedMappingTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/PredefinedMappingTest.java
@@ -112,4 +112,23 @@ class PredefinedMappingTest {
             assertThat(caseSensitiveDb.typeNameFor(STRING).value()).isEqualTo("TEXT");
         }
     }
+
+    @Test
+    @DisplayName("keep the MySQL mapping for a MySQL server of an unlisted version")
+    void selectMysqlMappingForOtherMysqlVersion() {
+        var mysqlOtherVersion = whichHoldsMetadata(MYSQL_9_7.getDatabaseProductName(), 8, 0);
+        // The binary collation is valid across MySQL versions, so the fix still applies.
+        assertThat(select(mysqlOtherVersion)).isEqualTo(MYSQL_9_7);
+    }
+
+    @Test
+    @DisplayName("fall back to portable type names for an unrecognized database")
+    void fallBackToPortableTypesForUnknownDatabase() {
+        var unknownDb = whichHoldsMetadata("AcmeDB", 1, 0);
+        var fallback = select(unknownDb);
+        // The MySQL-only collation must not leak into the DDL for a database that cannot parse it.
+        assertThat(fallback).isNotEqualTo(MYSQL_9_7);
+        assertThat(fallback.typeNameFor(STRING_512).value()).isEqualTo("VARCHAR(512)");
+        assertThat(fallback.typeNameFor(STRING).value()).isEqualTo("TEXT");
+    }
 }

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/given/JdbcStorageFactoryTestEnv.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/given/JdbcStorageFactoryTestEnv.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -49,7 +49,6 @@ import io.spine.test.storage.StgProjectId;
 
 import static io.spine.server.storage.jdbc.GivenDataSource.prefix;
 import static io.spine.server.storage.jdbc.PredefinedMapping.H2_2_4;
-import static io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_9_7;
 import static io.spine.server.storage.jdbc.Type.LONG;
 
 public final class JdbcStorageFactoryTestEnv {
@@ -62,7 +61,10 @@ public final class JdbcStorageFactoryTestEnv {
         var dataSource = dataSource();
         return JdbcStorageFactory.newBuilder()
                                  .setDataSource(dataSource)
-                                 .setTypeMapping(MYSQL_9_7)
+                                 // The data source is an in-memory H2 database, so the H2 mapping
+                                 // must be used. The MySQL mapping emits a MySQL-specific binary
+                                 // collation for string columns, which H2 cannot parse.
+                                 .setTypeMapping(H2_2_4)
                                  .build();
     }
 

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/mysql/MysqlIdCaseSensitivityTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/mysql/MysqlIdCaseSensitivityTest.java
@@ -41,9 +41,10 @@ import static io.spine.server.storage.jdbc.given.JdbcStorageFactoryTestEnv.singl
  * Verifies that identifiers are stored case-sensitively on MySQL.
  *
  * <p>MySQL compares non-binary string types case-insensitively by default. Entity identifiers
- * are stored in a {@code VARCHAR} column, so without an explicit binary collation two identifiers
- * differing only by case — such as a username {@code "name"} versus {@code "Name"} — would map to
- * the same row, and commands addressed to one entity would reach the other.
+ * are stored in a {@code VARCHAR} column, so without an explicit binary collation two
+ * identifiers differing only by case — such as a username {@code "name"} versus
+ * {@code "Name"} — would map to the same row, and commands addressed to one entity would
+ * reach the other.
  *
  * @see io.spine.server.storage.jdbc.PredefinedMapping#MYSQL_9_7
  */

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/mysql/MysqlIdCaseSensitivityTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/mysql/MysqlIdCaseSensitivityTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.jdbc.mysql;
+
+import io.spine.server.storage.RecordSpec;
+import io.spine.server.storage.RecordStorage;
+import io.spine.test.storage.StgProject;
+import io.spine.test.storage.StgProjectId;
+import io.spine.testing.SlowTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.spine.server.storage.jdbc.given.JdbcStorageFactoryTestEnv.singleTenantSpec;
+
+/**
+ * Verifies that identifiers are stored case-sensitively on MySQL.
+ *
+ * <p>MySQL compares non-binary string types case-insensitively by default. Entity identifiers
+ * are stored in a {@code VARCHAR} column, so without an explicit binary collation two identifiers
+ * differing only by case — such as a username {@code "name"} versus {@code "Name"} — would map to
+ * the same row, and commands addressed to one entity would reach the other.
+ *
+ * @see io.spine.server.storage.jdbc.PredefinedMapping#MYSQL_9_7
+ */
+@DisplayName("`JdbcRecordStorage` running on top of MySQL instance should")
+@SlowTest
+@EnableConditionally
+final class MysqlIdCaseSensitivityTest {
+
+    @Test
+    @DisplayName("not let identifiers differing only by case collide")
+    void notCollideOnIdCase() {
+        var factory = MysqlTests.newFactory();
+        RecordStorage<StgProjectId, StgProject> storage =
+                factory.createRecordStorage(singleTenantSpec(), projectSpec());
+
+        var lowerId = projectId("name");
+        var upperId = projectId("Name");
+        var lowerCase = project(lowerId, "Lower-case project");
+        var upperCase = project(upperId, "Upper-case project");
+
+        storage.write(lowerId, lowerCase);
+        storage.write(upperId, upperCase);
+
+        // Each identifier must address its own record. Under MySQL's default case-insensitive
+        // collation both writes would target a single row, so the second would overwrite the
+        // first and both reads would return `upperCase`.
+        assertThat(storage.read(lowerId)).hasValue(lowerCase);
+        assertThat(storage.read(upperId)).hasValue(upperCase);
+    }
+
+    private static RecordSpec<StgProjectId, StgProject> projectSpec() {
+        return new RecordSpec<>(StgProjectId.class, StgProject.class, StgProject::getId);
+    }
+
+    private static StgProjectId projectId(String value) {
+        return StgProjectId.newBuilder()
+                .setId(value)
+                .build();
+    }
+
+    private static StgProject project(StgProjectId id, String name) {
+        return StgProject.newBuilder()
+                .setId(id)
+                .setName(name)
+                .build();
+    }
+}

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/postgres/PostgresIdCaseSensitivityTest.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/postgres/PostgresIdCaseSensitivityTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.jdbc.postgres;
+
+import io.spine.testing.SlowTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.spine.server.storage.jdbc.PredefinedMapping.POSTGRESQL_10_1;
+import static io.spine.server.storage.jdbc.Type.STRING_512;
+
+/**
+ * Verifies that PostgreSQL keeps identifiers that differ only by case distinct, using the exact
+ * SQL type that the {@linkplain io.spine.server.storage.jdbc.PredefinedMapping#POSTGRESQL_10_1
+ * predefined PostgreSQL mapping} produces for identifier columns.
+ *
+ * <p>Unlike MySQL — whose default non-binary collation is case-insensitive — PostgreSQL compares
+ * strings case-sensitively by default: its default collations are deterministic, so equality is
+ * byte-exact and case folding is never applied. The plain {@code VARCHAR} mapping therefore needs
+ * no binary collation to keep {@code "name"} and {@code "Name"} apart, and this test asserts that
+ * behavior against a real PostgreSQL server.
+ */
+@DisplayName("PostgreSQL, with the predefined mapping, should")
+@SlowTest
+@Testcontainers(disabledWithoutDocker = true)
+final class PostgresIdCaseSensitivityTest {
+
+    @Container
+    private static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Test
+    @DisplayName("compare identifier columns case-sensitively without an explicit collation")
+    void keepCaseDistinctIdentifiersDistinct() throws SQLException {
+        // The SQL type the PostgreSQL mapping produces for identifier columns.
+        var idType = POSTGRESQL_10_1.typeNameFor(STRING_512).value();
+
+        try (var connection = DriverManager.getConnection(
+                postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+             var statement = connection.createStatement()) {
+
+            statement.execute("CREATE TABLE entity (id " + idType + " PRIMARY KEY)");
+            statement.executeUpdate("INSERT INTO entity(id) VALUES ('name')");
+            // A case-insensitive primary key would reject this as a duplicate of `name`.
+            statement.executeUpdate("INSERT INTO entity(id) VALUES ('Name')");
+
+            try (var rows = statement.executeQuery("SELECT count(*) FROM entity")) {
+                rows.next();
+                // Both identifiers are stored as distinct rows: PostgreSQL keeps them apart by
+                // default, so the plain `VARCHAR` mapping needs no binary collation.
+                assertThat(rows.getInt(1)).isEqualTo(2);
+            }
+        }
+    }
+}

--- a/rdbms/src/test/java/io/spine/server/storage/jdbc/postgres/package-info.java
+++ b/rdbms/src/test/java/io/spine/server/storage/jdbc/postgres/package-info.java
@@ -24,42 +24,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.test
-
 /**
- * Testcontainers for Java — provides throwaway, lightweight instances of databases and other
- * services running in Docker containers.
- *
- * The MySQL- and PostgreSQL-based storage tests use it to run against a real database server.
- *
- * The [mySql], [postgresql], and [junitJupiter] modules are released together with the
- * [core][lib] artifact. The version below is the latest one for which all modules are published.
- *
- * @see <a href="https://github.com/testcontainers/testcontainers-java">
- *     Testcontainers for Java at GitHub</a>
+ * Describes the test cases, which run against a real PostgreSQL database instance.
  */
-@Suppress("unused", "ConstPropertyName")
-object Testcontainers {
-    private const val version = "1.21.4"
-    private const val group = "org.testcontainers"
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.server.storage.jdbc.postgres;
 
-    /**
-     * The core Testcontainers library.
-     */
-    const val lib = "$group:testcontainers:$version"
+import com.google.errorprone.annotations.CheckReturnValue;
 
-    /**
-     * The JUnit 5 (Jupiter) integration.
-     */
-    const val junitJupiter = "$group:junit-jupiter:$version"
-
-    /**
-     * The MySQL container support.
-     */
-    const val mySql = "$group:mysql:$version"
-
-    /**
-     * The PostgreSQL container support.
-     */
-    const val postgresql = "$group:postgresql:$version"
-}
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/rdbms/src/test/kotlin/io/spine/server/storage/jdbc/operation/CreateTableSpec.kt
+++ b/rdbms/src/test/kotlin/io/spine/server/storage/jdbc/operation/CreateTableSpec.kt
@@ -36,6 +36,7 @@ import io.spine.server.storage.Storage
 import io.spine.server.storage.jdbc.GivenDataSource.whichIsStoredInMemory
 import io.spine.server.storage.jdbc.JdbcStorageFactory
 import io.spine.server.storage.jdbc.PredefinedMapping.H2_2_4
+import io.spine.server.storage.jdbc.PredefinedMapping.MYSQL_9_7
 import io.spine.server.storage.jdbc.given.JdbcStorageFactoryTestEnv.singleTenantSpec
 import io.spine.server.storage.jdbc.record.RecordTable
 import io.spine.test.storage.StgProject
@@ -46,8 +47,9 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
 /**
- * Tests that [CreateTable] escapes column and table names, so that records with columns
- * named after reserved SQL keywords can be stored.
+ * Tests that [CreateTable] composes a valid `CREATE TABLE` statement: it escapes column and
+ * table names so records with columns named after reserved SQL keywords can be stored, and it
+ * applies a binary collation to MySQL string columns so identifiers stay case-sensitive.
  */
 @DisplayName("`CreateTable` should")
 internal class CreateTableSpec {
@@ -62,6 +64,21 @@ internal class CreateTableSpec {
 
         // H2 quotes the reserved identifiers with the double quote character.
         sql shouldContain "\"group\""
+    }
+
+    @Test
+    fun `apply a binary collation to MySQL string columns to keep IDs case-sensitive`() {
+        val factory = mysqlFactory()
+        val tableSpec = factory.tableSpecFor(specWithGroupColumn())
+        val table = RecordTable.by(tableSpec, factory)
+
+        val sql = table.creationSql()
+
+        // The ID column is stored as `VARCHAR(512)`, and the `group` column as `TEXT`; both
+        // must carry the binary collation, otherwise MySQL compares them case-insensitively
+        // and distinct identifiers like `"name"` and `"Name"` collide.
+        sql shouldContain "VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin"
+        sql shouldContain "TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin"
     }
 
     @Test
@@ -100,6 +117,18 @@ internal class CreateTableSpec {
             JdbcStorageFactory.newBuilder()
                 .setDataSource(whichIsStoredInMemory(newUuid()))
                 .setTypeMapping(H2_2_4)
+                .build()
+
+        /**
+         * A factory configured with the [MYSQL_9_7] type mapping over an in-memory data source.
+         *
+         * The data source merely backs the SQL composition (no `CREATE TABLE` is executed), so
+         * the resulting DDL carries MySQL type names while staying free of a running MySQL server.
+         */
+        private fun mysqlFactory(): JdbcStorageFactory =
+            JdbcStorageFactory.newBuilder()
+                .setDataSource(whichIsStoredInMemory(newUuid()))
+                .setTypeMapping(MYSQL_9_7)
                 .build()
 
         private fun specWithGroupColumn(): RecordSpec<StgProjectId, StgProject> =

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of this library.
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.103")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.104")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of this library.
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.102")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.103")


### PR DESCRIPTION
Fixes #173.

## Problem

MySQL compares non-binary `VARCHAR`/`TEXT` case- and accent-insensitively by default. Spine stores entity identifiers (string IDs directly, message IDs as compact JSON) in `VARCHAR(512)`, so two distinct identifiers differing only by case — e.g. a username `"name"` vs `"Name"` — mapped to the same row, and commands for one entity were routed to another.

## Fix

`PredefinedMapping.MYSQL_9_7` now appends `CHARACTER SET utf8mb4 COLLATE utf8mb4_bin` to every character-based column type (`STRING_255`, `STRING_512`, `STRING`), restoring exact, case-sensitive matching. The collation lives in the type mapping — the layer already responsible for DB-specific type names — so it flows into `CreateTable` for both the ID and data columns with no change to the DDL builder. `utf8mb4` keeps the full Unicode range; the collation doesn't change the stored byte width, so the `VARCHAR(512)` primary key stays within InnoDB's index-length limit.

The dialect-specific type-name constants were extracted from `PredefinedMapping` into package-level `MySqlTypeNames` / `PostgreSqlTypeNames` for a clearer, more visible design.

### Product-aware fallback

Following review, `PredefinedMapping.select()` no longer falls back to the MySQL-specific mapping for non-MySQL databases. A recognized product (MySQL, PostgreSQL, or H2) reported at an *unlisted version* now uses **that product's own dialect mapping**; only an unrecognized database falls back to a neutral `GENERIC_MAPPING` with portable type names. (Previously the fallback emitted MySQL-only DDL that other engines can't parse.)

The test harness `JdbcStorageFactoryTestEnv.newFactory()` previously ran the MySQL mapping over an in-memory H2 database — which worked only because `MYSQL_9_7` and `H2_2_4` used to be byte-identical. It now uses `H2_2_4`, the mapping that matches its data source.

## PostgreSQL

PostgreSQL compares strings **case-sensitively by default** — its default collations are deterministic, so equality is byte-exact and case folding is never applied — so it does **not** have the MySQL collision, and the plain `VARCHAR`/`TEXT` mapping needs no collation. This is verified empirically rather than assumed.

## Tests

- **`MysqlIdCaseSensitivityTest`** (Docker-gated) — `"name"`/`"Name"` do not collide on a real MySQL 8 container. Confirmed to **fail without the fix**.
- **`PostgresIdCaseSensitivityTest`** (Docker-gated) — the PostgreSQL mapping's ID type (`VARCHAR(512)`) keeps case-distinct IDs distinct on a real PostgreSQL 16 container.
- **`PredefinedMappingTest`** — pins the MySQL DDL, the product-aware `select()` behavior, and that H2/PostgreSQL stay plain.
- **`CreateTableSpec`** — the collation reaches the generated `CREATE TABLE`.
- Full `./gradlew :rdbms:test` is green (371 tests, incl. the MySQL & PostgreSQL suites); `checkstyleMain`, `detekt`, `pmdMain` pass.

## Dependencies

- Added the PostgreSQL JDBC driver (test scope) for the new PostgreSQL test — `org.postgresql:postgresql:42.7.11`.
- Bumped HikariCP `5.0.1` → `7.1.0` (full suite verified green on JDK 17).

## Docs

`docs/type-mapping.md` gains a "Case sensitivity on MySQL" section (with migration guidance and a warning against reverting to case-insensitive types); `docs/tables.md` cross-references it from the `ID` column.

## Notes for reviewers

- **Existing MySQL tables** aren't altered by the framework, so deployments with tables created before this change keep their old collation and would need a manual `ALTER TABLE … COLLATE utf8mb4_bin` (documented in `type-mapping.md`).
- Version bumped to `2.0.0-SNAPSHOT.104`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
